### PR TITLE
docs: add CLAUDE.md — agent orientation stub

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,45 @@
+# Nordri — Cluster Substrate (Tier 1)
+
+Nordri is the foundation layer: Traefik, Crossplane, Velero, Longhorn, Garage S3.
+ArgoCD is bootstrapped here and deploys everything above via `nidavellir-apps.yaml`.
+
+**Full agent context:** [`yggdrasil/CLAUDE.md`](../yggdrasil/CLAUDE.md) and
+[`yggdrasil/docs/ecosystem-architecture.md`](../yggdrasil/docs/ecosystem-architecture.md)
+
+---
+
+## Key Commands
+
+### Push changes to in-cluster Gitea (after local edits)
+```bash
+./update-embedded-git.sh gke
+```
+If ArgoCD doesn't auto-sync after push:
+```bash
+kubectl annotate application vegvisir -n argocd argocd.argoproj.io/refresh=hard --overwrite
+```
+
+### Run kuttl tests (GKE)
+```bash
+kubectl kuttl test --config kuttl-test-gke.yaml
+# Tests: argocd, gateway, crossplane (shared); velero (GKE)
+```
+
+### Provision a fresh GKE test cluster
+```bash
+./scripts/gke-provision.sh
+```
+
+---
+
+## Key Gotchas
+
+- **kuttl CWD**: `commands:` steps run from the test case directory, not the project root.
+  Use `../../../` to reach project-root files. See kuttl-testing skill.
+- **kuttl conditions**: assertions on `status.conditions` arrays must include ALL conditions
+  the live resource has — not just the one you care about. Check with `kubectl get -o yaml`.
+- **ArgoCD webhook drift**: Kubernetes defaulting webhooks add `group:` fields at admission
+  time. These must be present in git manifests to avoid OutOfSync. Already fixed for Traefik
+  Gateway and cert-manager resources — see `MEMORY.md` for the full list.
+- **Gitea uses SQLite** intentionally (bootstrap simplicity). Upgrade to PostgreSQL via Mimir
+  is planned (nordri#2, blocked by mimir#1 + mimir#2).


### PR DESCRIPTION
## Summary
- Add thin \`CLAUDE.md\` for agent cold-start orientation: repo role, key commands, repo-specific gotchas, and pointer to \`yggdrasil/CLAUDE.md\` for full context

## Test plan
- [ ] Open a fresh Claude Code session in this repo and confirm CLAUDE.md loads and gives correct orientation

## Related
- Master agent manual: [yggdrasil/CLAUDE.md](https://github.com/SiliconSaga/yggdrasil/blob/main/CLAUDE.md)

🤖 Assisted by Claude Code
<!-- Commit-level attribution (Co-Authored-By trailers) is separate — see topic-branch-workflow skill -->