### PR TITLE
fix: add cluster-admin RBAC for Provider-Helm

### DIFF
--- a/platform/fundamentals/manifests/crossplane-providers.yaml
+++ b/platform/fundamentals/manifests/crossplane-providers.yaml
@@ -35,6 +35,32 @@ spec:
   runtimeConfigRef:
     name: provider-kubernetes-config
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: provider-helm-sa
+  namespace: crossplane
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: DeploymentRuntimeConfig
+metadata:
+  name: provider-helm-config
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  deploymentTemplate:
+    spec:
+      selector:
+        matchLabels:
+          pkg.crossplane.io/provider: provider-helm
+      template:
+        spec:
+          serviceAccountName: provider-helm-sa
+          containers:
+          - name: package-runtime
+---
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
@@ -43,6 +69,23 @@ metadata:
     argocd.argoproj.io/sync-wave: "5"
 spec:
   package: xpkg.upbound.io/crossplane-contrib/provider-helm:v1.0.0
+  runtimeConfigRef:
+    name: provider-helm-config
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: provider-helm-admin-binding
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+subjects:
+- kind: ServiceAccount
+  name: provider-helm-sa
+  namespace: crossplane
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil/blob/main/docs/gdd/index.md).

## Summary

- Add named ServiceAccount, DeploymentRuntimeConfig, and ClusterRoleBinding for Provider-Helm, matching the existing pattern for Provider-Kubernetes
- Without this, Provider-Helm cannot create namespaces or install Helm charts — it blocks any Crossplane composition using Helm releases (including Heimdall)

## Context

Provider-Kubernetes already had a stable SA (`provider-kubernetes-sa`) with `cluster-admin` via a `DeploymentRuntimeConfig`. Provider-Helm was missing all of this, using only its auto-generated SA with no cluster permissions. Discovered while deploying Heimdall's observability stack.

## Test plan

- [ ] Verify Provider-Helm pod restarts with the new SA: `kubectl get pod -n crossplane -l pkg.crossplane.io/provider=provider-helm -o jsonpath='{.items[0].spec.serviceAccountName}'` should return `provider-helm-sa`
- [ ] Verify ClusterRoleBinding exists: `kubectl get clusterrolebinding provider-helm-admin-binding`
- [ ] Verify Helm-based compositions can install charts (e.g. Heimdall's kube-prometheus-stack)
