### PR TITLE
fix(traefik): allow encoded hash (%23) in URL paths

### DIFF
--- a/platform/fundamentals/apps/traefik.yaml
+++ b/platform/fundamentals/apps/traefik.yaml
@@ -26,8 +26,19 @@ spec:
         ports:
           web:
             exposedPort: 80
+            # Allow encoded `#` (%23) in URL paths.
+            # Required for Matrix Synapse and other APIs that put room aliases
+            # like #room:server in path segments. Traefik 3.6.4+ rejects these
+            # by default (CVE hardening). Safe for our use cases.
+            # See: https://doc.traefik.io/traefik/security/request-path/
+            http:
+              encodedCharacters:
+                allowEncodedHash: true
           websecure:
             exposedPort: 443
+            http:
+              encodedCharacters:
+                allowEncodedHash: true
   destination:
     server: https://kubernetes.default.svc
     namespace: kube-system


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via GDD.

## Summary

- Allow encoded hash (%23) in Traefik URL paths via the `encodedCharacters.allowEncodedHash: true` setting on both web and websecure entrypoints.
- Required for Matrix Synapse and any other API that puts identifiers like `#room:server` in URL path segments. Traefik 3.6.4+ rejects these by default as part of CVE hardening.
- Discovered while building the Knarr config reconciler, which uses `GET /_matrix/client/v3/directory/room/{alias}` for room lookup. Returns empty 400 from Traefik even though Synapse handles the request fine when accessed directly.
- Verified locally on `k3d-nordri-test`: alias resolution returns 200 OK after the change (was returning 400 with empty body).

## Test plan

- [ ] Sync ArgoCD on the affected cluster
- [ ] Confirm Traefik pod restarts with new args (`--entryPoints.web.http.encodedCharacters.allowEncodedHash=true`)
- [ ] Test via Knarr CLI: `knarr config audit` should resolve aliases without 400 errors
- [ ] Verify normal traffic still works (Element X, Kafka UI, etc.)

## Related

- Spotted while testing https://github.com/SiliconSaga/knarr (config reconciler PR pending)
- Reference: https://doc.traefik.io/traefik/security/request-path/
