### PR TITLE
feat(crossplane): cluster-identity pattern + storage class cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,17 @@ We use a **Kustomize-based App-of-Apps** pattern to handle environment differenc
 3.  **Application Creation**: The overlay includes the specific `Application` manifests from `apps/`.
 4.  **Resource Creation**: The overlay includes raw manifests from `manifests/`.
 
+## Composition Patterns
+
+Nordri exposes substrate patterns that downstream components (Heimdall, Mimir,
+…) consume in their Crossplane compositions:
+
+* **[Cluster identity](docs/cluster-identity.md)** — workspace-scoped
+  `EnvironmentConfig/cluster-identity` provisioned per environment. Compositions
+  read per-cluster facts (`storageClass`, `domain`, `environment`) from it via
+  `function-environment-configs` so claims and templates stay
+  environment-agnostic. Read this before authoring a new Composition.
+
 ## Important Notes
 
 *   **Storage Strategy**: The default `local-path` provisioner (built-in to k3d/k3s) is used for development. It is node-local and does **not replicate** across nodes.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -36,6 +36,12 @@ Provision the raw cluster before running any scripts.
 ### Layer 2.7 — Crossplane Providers + Functions
 - Applies `crossplane-providers.yaml` and waits for all providers to become Healthy
 - Must be healthy before ProviderConfigs (Layer 2.8) can be applied
+- Functions: `function-auto-ready`, `function-go-templating`,
+  `function-environment-configs`. The last one is required for the
+  cluster-identity pattern — see [`cluster-identity.md`](cluster-identity.md)
+  for how downstream compositions consume per-environment values
+  (`storageClass`, `domain`, etc.) without claim parameters or per-environment
+  hydration
 
 ### Layer 2.8 — Crossplane ProviderConfigs + RBAC
 - Applies `crossplane-configs.yaml` (ProviderConfig CRDs now exist from Layer 2.7)

--- a/docs/cluster-identity.md
+++ b/docs/cluster-identity.md
@@ -1,0 +1,155 @@
+# Cluster Identity (`EnvironmentConfig/cluster-identity`)
+
+Nordri provisions a workspace-scoped `EnvironmentConfig` named `cluster-identity`
+on every cluster it bootstraps. Downstream Crossplane compositions read it via
+`function-environment-configs` so claim authors don't have to thread cluster
+facts (storage class, ingress domain, environment kind) through every claim,
+and templates don't have to branch on a `parameters.environment` ternary.
+
+## The problem it solves
+
+Without cluster identity, a single composition needs to know — at template
+render time — *which* cluster it's running on so it can pick the right
+StorageClass, ingress domain, and replica count. The historical pattern was a
+required `parameters.environment` field on the claim plus per-step ternaries:
+
+```yaml
+storageClassName: {{ if eq .observed.composite.resource.spec.parameters.environment "gke" }}standard-rwo{{ else }}local-path{{ end }}
+```
+
+That works for two environments but doesn't scale: every composition repeats
+the same branching, every claim repeats the same value, and every new
+environment adds another `else if`. Worse, the same Git repo can't be applied
+identically to homelab and GKE — claims have to be hydrated with environment
+values per cluster.
+
+Cluster identity inverts the relationship: the *cluster* declares its facts
+once, and compositions read them.
+
+## What's in cluster-identity
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: cluster-identity
+data:
+  environment: homelab    # or "gke" — controls replica counts, etc.
+  storageClass: local-path # or "standard-rwo" — used by all PVC-bound resources
+  domain: homelab.local   # or "cmdbee.org" — base domain for ingress hosts
+```
+
+Per-environment definitions live in
+`platform/fundamentals/manifests/cluster-identity-{homelab,gke}.yaml`. Each
+overlay's `kustomization.yaml` includes only its own (the same file pattern as
+`longhorn`/`garage` for homelab-only apps). The resource name is identical in
+both — only the values differ — so compositions stay environment-agnostic.
+
+## How a composition consumes it
+
+Two pipeline steps. **Step 0** loads the EnvironmentConfig into the request
+context; subsequent `function-go-templating` steps read from
+`.context."apiextensions.crossplane.io/environment"`:
+
+```yaml
+spec:
+  pipeline:
+  - step: load-cluster-identity
+    functionRef:
+      name: function-environment-configs
+    input:
+      apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+      kind: Input
+      spec:
+        environmentConfigs:
+        - type: Reference
+          ref:
+            name: cluster-identity
+
+  - step: render-resources
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: Inline
+      inline:
+        template: |
+          {{- $identity := index .context "apiextensions.crossplane.io/environment" -}}
+          {{- $storageClass := $identity.storageClass -}}
+          {{- $domain := $identity.domain -}}
+          # ... use $storageClass, $domain, $identity.environment ...
+```
+
+The Go template key contains slashes and dots, so use Go's `index` rather than
+dotted access. Common idiom: bind `$identity` once at the top of the template
+and reference fields off it.
+
+## Optional claim overrides
+
+Claim parameters are still useful as a per-claim escape hatch. The convention:
+a claim parameter, if present, overrides the cluster-identity value. Sprig's
+`default` makes this a one-liner:
+
+```go
+{{- $env := .observed.composite.resource.spec.parameters.environment | default $identity.environment -}}
+{{- $domain := .observed.composite.resource.spec.parameters.domain | default $identity.domain -}}
+```
+
+The XRD declares the parameter without a `default:` and without listing it in
+`required:`, so claims can omit it entirely:
+
+```yaml
+parameters:
+  type: object
+  properties:
+    environment:
+      type: string
+      enum: ["homelab", "gke"]
+      description: "Optional override for the target environment. Defaults to EnvironmentConfig/cluster-identity."
+    domain:
+      type: string
+      description: "Optional override for the ingress base domain. Defaults to EnvironmentConfig/cluster-identity."
+```
+
+## Adding a new field
+
+Extend cluster identity when a new fact is environment-dependent and shared
+across compositions. Examples that would belong:
+
+- An `objectStoreEndpoint` once Garage/Seaweed/GCS becomes common across
+  observability, backup, and platform components
+- An `oidcIssuerUrl` once Keycloak issues IDs cluster-wide
+- A `defaultPullSecret` reference for private registries
+
+To add one:
+
+1. Add the field to both `cluster-identity-homelab.yaml` and
+   `cluster-identity-gke.yaml` under `data:`. Always extend both at once —
+   they're parallel; missing keys cause "<no value>" surprises in templates.
+2. Compositions that want it read it the same way:
+   `{{ $identity.objectStoreEndpoint }}`.
+3. Update this doc.
+
+Avoid putting per-claim or per-workload settings here. Cluster identity is
+about cluster-wide facts; resource sizing, retention, feature flags belong on
+the claim.
+
+## Why a function instead of `spec.environment.environmentConfigs`
+
+Crossplane v1 Compositions had a `spec.environment.environmentConfigs` field
+that Crossplane itself merged into the request context. v2 removed it; the
+v2-native pattern is to call `function-environment-configs` explicitly as a
+pipeline step. Bonus: the function model composes well with multiple
+EnvironmentConfigs (e.g. cluster identity *plus* a per-tenant overlay) and
+keeps composition logic visible in the pipeline rather than hidden in a
+top-level field.
+
+## See also
+
+- Heimdall is the proving ground — see
+  [`components/heimdall/crossplane/composition.yaml`](../../heimdall/crossplane/composition.yaml).
+- Function source:
+  https://github.com/crossplane-contrib/function-environment-configs
+- `function-go-templating` template syntax:
+  https://github.com/crossplane-contrib/function-go-templating

--- a/docs/cluster-identity.md
+++ b/docs/cluster-identity.md
@@ -148,7 +148,8 @@ top-level field.
 ## See also
 
 - Heimdall is the proving ground — see
-  [`components/heimdall/crossplane/composition.yaml`](../../heimdall/crossplane/composition.yaml).
+  [`heimdall/crossplane/composition.yaml`](https://github.com/SiliconSaga/heimdall/blob/main/crossplane/composition.yaml)
+  (separate repo).
 - Function source:
   https://github.com/crossplane-contrib/function-environment-configs
 - `function-go-templating` template syntax:

--- a/platform/fundamentals/apps/longhorn.yaml
+++ b/platform/fundamentals/apps/longhorn.yaml
@@ -15,6 +15,12 @@ spec:
       values: |
         preUpgradeChecker:
           jobEnabled: false
+        # Cluster ships with local-path (Rancher) as default StorageClass; keep
+        # it that way. Compositions explicitly reference longhorn or local-path
+        # via the cluster-identity EnvironmentConfig, so the default-class
+        # fallback only matters for workloads that omit storageClassName.
+        persistence:
+          defaultClass: false
   destination:
     server: https://kubernetes.default.svc
     namespace: longhorn

--- a/platform/fundamentals/manifests/cluster-identity-gke.yaml
+++ b/platform/fundamentals/manifests/cluster-identity-gke.yaml
@@ -1,0 +1,14 @@
+# Cluster identity for Crossplane compositions (GKE).
+# Loaded into the pipeline context by function-environment-configs so
+# compositions can stay environment-agnostic — they read storageClass,
+# domain, etc. from this resource instead of branching on a claim parameter.
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: cluster-identity
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+data:
+  environment: gke
+  storageClass: standard-rwo
+  domain: cmdbee.org

--- a/platform/fundamentals/manifests/cluster-identity-homelab.yaml
+++ b/platform/fundamentals/manifests/cluster-identity-homelab.yaml
@@ -1,0 +1,14 @@
+# Cluster identity for Crossplane compositions (homelab).
+# Loaded into the pipeline context by function-environment-configs so
+# compositions can stay environment-agnostic — they read storageClass,
+# domain, etc. from this resource instead of branching on a claim parameter.
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: cluster-identity
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+data:
+  environment: homelab
+  storageClass: local-path
+  domain: homelab.local

--- a/platform/fundamentals/manifests/crossplane-providers.yaml
+++ b/platform/fundamentals/manifests/crossplane-providers.yaml
@@ -119,3 +119,16 @@ metadata:
     argocd.argoproj.io/sync-wave: "5"
 spec:
   package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.4.0
+---
+# Required by Crossplane v2: spec.environment was removed from Composition,
+# so EnvironmentConfigs are loaded into the pipeline context via this function.
+# Used by the cluster-identity pattern (environment, storageClass, domain) so
+# composition templates stay environment-agnostic.
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-environment-configs
+  annotations:
+    argocd.argoproj.io/sync-wave: "5"
+spec:
+  package: xpkg.upbound.io/crossplane-contrib/function-environment-configs:v0.4.0

--- a/platform/fundamentals/overlays/gke/kustomization.yaml
+++ b/platform/fundamentals/overlays/gke/kustomization.yaml
@@ -10,6 +10,9 @@ resources:
   # Shared Manifests
   - ../../manifests/crossplane-providers.yaml
   - ../../manifests/crossplane-configs.yaml
+
+  # GKE Specific Manifests
+  - ../../manifests/cluster-identity-gke.yaml
   # Note: Gateway API CRDs, Traefik Gateway resource, and ClusterIssuers are
   # managed by the Nidavellir platform component, not Nordri. cert-manager
   # itself is pre-installed on this cluster and also excluded.

--- a/platform/fundamentals/overlays/homelab/kustomization.yaml
+++ b/platform/fundamentals/overlays/homelab/kustomization.yaml
@@ -14,6 +14,9 @@ resources:
   # Homelab Specific Apps
   - ../../apps/longhorn.yaml
   - ../../apps/garage.yaml
+
+  # Homelab Specific Manifests
+  - ../../manifests/cluster-identity-homelab.yaml
   
   # Exclusions
   # We do NOT include cert-manager.yaml here.

--- a/tests/e2e/shared/crossplane/00-assert.yaml
+++ b/tests/e2e/shared/crossplane/00-assert.yaml
@@ -1,7 +1,7 @@
 # tests/e2e/shared/crossplane/00-assert.yaml
 # Assert all Crossplane providers and functions are Healthy.
 # Providers: provider-helm, provider-kubernetes
-# Functions: function-auto-ready, function-go-templating
+# Functions: function-auto-ready, function-go-templating, function-environment-configs
 apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
@@ -39,6 +39,17 @@ apiVersion: pkg.crossplane.io/v1beta1
 kind: Function
 metadata:
   name: function-go-templating
+status:
+  conditions:
+  - type: Healthy
+    status: "True"
+  - type: Installed
+    status: "True"
+---
+apiVersion: pkg.crossplane.io/v1beta1
+kind: Function
+metadata:
+  name: function-environment-configs
 status:
   conditions:
   - type: Healthy


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil/blob/main/docs/gdd/index.md).

## Summary

- Add `function-environment-configs` to the Crossplane substrate. Crossplane v2 removed `spec.environment.environmentConfigs` from `Composition`, so EnvironmentConfigs must now be loaded into the pipeline context via this dedicated function. Healthy check added to the shared kuttl assertion.
- Introduce a workspace-scoped `EnvironmentConfig/cluster-identity` per environment (homelab and gke). Exposes `environment`, `storageClass`, and `domain` so downstream compositions (Heimdall first, then others) can stay environment-agnostic and read from context instead of branching on `parameters.environment` in template logic. Same resource name in both files; values differ. Wired into the env overlays the same way as longhorn/garage.
- Fix dual default StorageClass on homelab: Longhorn's chart was setting its own class as default, racing with Rancher's `local-path`. `persistence.defaultClass: false` makes `local-path` the sole default. Crossplane compositions don't rely on the cluster default — this is purely about the fallback for workloads that omit `storageClassName`.

## Test plan

- [ ] Substrate verification — apply the overlay (`kubectl apply -k platform/fundamentals/overlays/homelab`) and confirm:
  - [ ] `function-environment-configs` reaches `Healthy=True`
  - [ ] `EnvironmentConfig/cluster-identity` exists with the homelab values (`environment=homelab`, `storageClass=local-path`, `domain=homelab.local`)
  - [ ] Only `local-path` shows `(default)` in `kubectl get storageclass`
- [ ] Composition pipeline reads the context — a minimal composition that uses both `function-environment-configs` (referencing `cluster-identity`) and `function-go-templating` to emit a ConfigMap renders with values pulled from the EnvironmentConfig. Verified locally during development.
- [ ] Run the kuttl substrate suite — `kubectl kuttl test --config kuttl-test-homelab.yaml` (or `-gke.yaml`) — and confirm the new function assertion passes.

## Related

- Unblocks the cluster-identity work tracked in the workspace Thalamus (downstream Heimdall/Mimir composition migration).
