### PR TITLE
fix: gate rdctl preflight on TARGET=homelab

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -100,7 +100,11 @@ command -v jq >/dev/null 2>&1 || {
 echo "🚀 Bootstrapping Nordri for target: $TARGET"
 
 # --- Step 0: Pre-flight Checks (Rancher Desktop Specifics) ---
-if command -v rdctl &> /dev/null; then
+# Only relevant when the TARGET is the local Rancher Desktop VM (homelab path).
+# `rdctl` may be installed on a workstation that's also being used to bootstrap
+# a remote cluster (e.g. GKE) — in that case the VM preflight is meaningless
+# and `rdctl shell` would target the wrong machine.
+if [[ "$TARGET" == "homelab" ]] && command -v rdctl &> /dev/null; then
     echo "🔍 Detected Rancher Desktop (rdctl). Checking for required VM dependencies..."
     # Check for iscsiadm (required for Longhorn)
     if ! rdctl shell which iscsiadm >/dev/null 2>&1; then


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Gates the Rancher Desktop VM dependency check in `bootstrap.sh` on `TARGET == homelab`. The check (`rdctl shell which iscsiadm`) only makes sense when the target *is* the local Rancher Desktop VM, but it was firing whenever `rdctl` was on PATH regardless of TARGET. On a workstation with Rancher Desktop installed for local testing alongside `kubectl` configured for a remote cluster (a common dev setup), `bootstrap.sh gke` would shell into the wrong cluster and abort.
- Discovered while re-bootstrapping Seed Gitea on GKE after the May-2 data-loss postmortem — the rebuild aborted on this preflight before reaching the Gitea install step.

## Test plan

- [x] `bootstrap.sh gke` now skips the Rancher Desktop VM check on a workstation that has `rdctl` installed (validated on the GKE rebootstrap that motivated this fix)
- [ ] `bootstrap.sh homelab` still runs the check on a Rancher-Desktop-targeting workstation (regression test — manually validate on next homelab bring-up)
- [ ] No CI test added (the preflight is environment-specific; existing kuttl coverage is unaffected)

## Related

- Separate apk-install bug inside the VM was visible in the original error output (`nsenter: can't execute 'sudo apk update && ...'` — the whole quoted command is being passed as a single executable path) — not addressed here, since this fix avoids the code path on the cases where it would matter incorrectly. Worth a follow-up if the homelab path needs the auto-install to actually work.
