### PR TITLE
fix(ingress): gitea HTTPS-only with Let's Encrypt cert

### DIFF
--- a/platform/fundamentals/ingress/gitea-cert.yaml
+++ b/platform/fundamentals/ingress/gitea-cert.yaml
@@ -1,0 +1,58 @@
+# Per-host TLS for the Seed Gitea HTTPRoute on GKE.
+#
+# Issues a Let's Encrypt cert for `gitea.cmdbee.org` via cert-manager's
+# `letsencrypt-gateway` ClusterIssuer (HTTP-01 over the Traefik Gateway
+# port-80 listener — see nidavellir/vegvisir/manifests/letsencrypt-gateway-issuer.yaml).
+# The resulting `gitea-tls` Secret lives in the gitea namespace; the
+# ReferenceGrant below lets the kube-system Gateway read it for SNI
+# matching at TLS handshake time.
+#
+# Vegvísir's `traefik-gateway.yaml` lists `gitea-tls` in its websecure
+# `certificateRefs` (mirror PR landed alongside this one).
+#
+# This is the same per-host pattern ting uses on `frontstate.org` /
+# `cmdbee.org`. The longer-term fix is the Vegvísir wildcard cert arc
+# (`*.cmdbee.org`), at which point this Certificate becomes redundant
+# and can be removed along with the ReferenceGrant.
+#
+# Sync-wave 16: after letsencrypt-gateway ClusterIssuer (wave 15). The
+# HTTPRoute itself is wave 14; HTTPRoute can attach to the Gateway
+# before the per-host cert is ready (Traefik falls back to the default
+# self-signed cert via SNI matching until gitea-tls becomes available).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gitea-cert
+  namespace: gitea
+  annotations:
+    argocd.argoproj.io/sync-wave: "16"
+spec:
+  secretName: gitea-tls
+  privateKey:
+    rotationPolicy: Always
+  issuerRef:
+    name: letsencrypt-gateway
+    kind: ClusterIssuer
+  dnsNames:
+    - gitea.cmdbee.org
+---
+# Cross-namespace allowance: lets the traefik-gateway in kube-system read
+# the gitea-tls Secret in the gitea namespace so it can be served via SNI
+# for https://gitea.cmdbee.org. Required because the Gateway's
+# certificateRefs entries point at a Secret in a different namespace.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: gateway-read-gitea-tls
+  namespace: gitea
+  annotations:
+    argocd.argoproj.io/sync-wave: "16"
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: kube-system
+  to:
+    - group: ""
+      kind: Secret
+      name: gitea-tls

--- a/platform/fundamentals/ingress/gitea-gke.yaml
+++ b/platform/fundamentals/ingress/gitea-gke.yaml
@@ -4,36 +4,28 @@
 # in-cluster Gitea is reachable via the wildcard A record that already
 # points at the Traefik LB.
 #
-# *** Cleartext caveat ***
+# **HTTPS-only.** The companion `gitea-cert.yaml` issues a real Let's
+# Encrypt cert for `gitea.cmdbee.org` via cert-manager and the Vegvísir
+# `traefik-gateway` lists `gitea-tls` in its `certificateRefs`, so the
+# `websecure` listener serves a browser-trusted cert via SNI. The `web`
+# parentRef is intentionally absent — admin basic auth and git push
+# should never travel cleartext over the public LB. cert-manager's
+# HTTP-01 ACME challenges still work because they create their own
+# ephemeral HTTPRoute on the Gateway's port-80 listener; that's the
+# Gateway's concern, not gitea's.
 #
-# This route binds to BOTH the `web` (HTTP) and `websecure` (HTTPS)
-# listeners. CodeRabbit correctly flagged that exposing a public hostname
-# on plaintext is a security smell — basic auth and git operations should
-# travel over TLS. The reason we still allow `web` here today:
+# Operational note: `update-embedded-git.sh gke` should now use
+# `GITEA_HOST=gitea.cmdbee.org GITEA_SCHEME=https` (defaults still work
+# via the kubectl port-forward path which is HTTP, but that's
+# in-cluster, not over the LB).
 #
-# 1. The Gateway's `websecure` listener only references the cluster-wide
-#    self-signed `traefik-gateway-default-cert`. There is no per-host or
-#    wildcard cert wired into the listener yet.
-# 2. So `https://gitea.cmdbee.org` reaches Traefik but is served by the
-#    default self-signed cert — browser warning, SAN mismatch, git push
-#    needs `http.sslVerify=false`. That is *worse* practical UX than HTTP
-#    until the wildcard cert is in place.
-# 3. The cluster is experimental, internal, and not handling real user
-#    secrets. Cleartext basic auth is acceptable in this transient state.
+# Sync-wave 14: after Vegvísir's `traefik-gateway` resource (wave 13).
+# The Gateway must exist before this HTTPRoute can attach. ArgoCD will
+# retry until the parentRef resolves, but applying after the Gateway
+# avoids spurious "ResolvedRefs=False" noise on first sync.
 #
-# The fix is the wildcard-cert work tracked as a Vegvísir follow-up (issue
-# scoped, see Thalamus / project tracker). Once a `*.cmdbee.org` cert is
-# referenced on the listener, `update-embedded-git.sh` callers can flip to
-# `GITEA_SCHEME=https` and we can either drop the `web` parentRef here or
-# turn it into an HTTP→HTTPS redirect.
-#
-# Sync-wave 14: after Vegvísir's `traefik-gateway` resource (wave 13). The
-# Gateway must exist before this HTTPRoute can attach. ArgoCD will retry
-# until the parentRef resolves, but applying after the Gateway avoids
-# spurious "ResolvedRefs=False" noise on first sync.
-#
-# This file is GKE-specific because static Kustomize manifests can't read
-# EnvironmentConfig at apply time. Crossplane-driven ingresses in
+# This file is GKE-specific because static Kustomize manifests can't
+# read EnvironmentConfig at apply time. Crossplane-driven ingresses in
 # downstream components (e.g. cluster-identity-demo) DO use
 # cluster-identity.domain at composition time.
 apiVersion: gateway.networking.k8s.io/v1
@@ -49,11 +41,6 @@ spec:
       name: traefik-gateway
       namespace: kube-system
       kind: Gateway
-      sectionName: web
-    - group: gateway.networking.k8s.io
-      name: traefik-gateway
-      namespace: kube-system
-      kind: Gateway
       sectionName: websecure
   hostnames:
     - gitea.cmdbee.org
@@ -63,5 +50,13 @@ spec:
             type: PathPrefix
             value: /
       backendRefs:
-        - name: gitea-http
+        # `group: ""` and `kind: Service` and `weight: 1` are added by the
+        # Gateway API admission webhook on apply; specified here so the
+        # manifest matches what's stored in etcd and ArgoCD doesn't flag
+        # this resource as OutOfSync (the original miss was the chronic
+        # OutOfSync on `layer4-fundamentals` for many days).
+        - group: ""
+          kind: Service
+          name: gitea-http
           port: 3000
+          weight: 1

--- a/platform/fundamentals/overlays/gke/kustomization.yaml
+++ b/platform/fundamentals/overlays/gke/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
 
   # GKE Specific Ingress Routes
   - ../../ingress/gitea-gke.yaml
+  - ../../ingress/gitea-cert.yaml


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- **Drop the `web` parentRef on the gitea HTTPRoute.** Admin basic-auth and git push traffic should never travel cleartext over the public LoadBalancer. The cluster's prior position ("cleartext is acceptable while HTTPS is self-signed") becomes obsolete now that we issue a real cert. cert-manager HTTP-01 challenges still work via the Gateway's port-80 listener (their own ephemeral HTTPRoute).
- **Issue `gitea.cmdbee.org` cert via cert-manager + `letsencrypt-gateway` ClusterIssuer.** Same pattern ting uses: `Certificate` in the gitea namespace + `ReferenceGrant` allowing the kube-system Gateway to read the resulting `gitea-tls` Secret. New file: `platform/fundamentals/ingress/gitea-cert.yaml`. Wired into the GKE overlay kustomization.
- **Resolve the chronic `layer4-fundamentals` OutOfSync** by adding the webhook-defaulted fields (`group: ""`, `kind: Service`, `weight: 1`) to the HTTPRoute's `backendRefs`. Same pattern as prior fixes for Traefik Gateway and cert-manager resources; gitea was missed in those rounds.

Companion change in nidavellir adds `gitea-tls` to the `traefik-gateway` `websecure` listener `certificateRefs` (PR opened separately).

## Test plan

- [ ] After both PRs merge: `kubectl -n gitea get certificate gitea-cert` reports `Ready=True` within ~2 minutes (cert-manager HTTP-01 ACME issuance time)
- [ ] `kubectl -n gitea get secret gitea-tls` exists with TLS data
- [ ] `kubectl get applications -n argo layer4-fundamentals` reports `Synced` (chronic OutOfSync resolved)
- [ ] `curl -v https://gitea.cmdbee.org/api/v1/version` returns Gitea's version JSON with a browser-trusted cert (no `--insecure` needed)
- [ ] `curl -v http://gitea.cmdbee.org/` returns Traefik 404 (no HTTPRoute attached to web listener for this hostname any more)
- [ ] `update-embedded-git.sh gke` still works via the default kubectl port-forward path (HTTP, in-cluster)
- [ ] `GITEA_HOST=gitea.cmdbee.org GITEA_SCHEME=https update-embedded-git.sh gke` works over the public LB without `sslVerify=false`

## Related

- Companion: nidavellir PR adding `gitea-tls` to Gateway `certificateRefs`
- Out of scope: `gitea-homelab.yaml` carries the same cosmetic backendRefs drift; not addressed in this PR (homelab uses non-public `gitea.localhost`, not running right now). Same pattern can be applied next time homelab is exercised.
- Longer-term: Vegvísir wildcard-cert arc (`*.cmdbee.org`) makes per-host cert + ReferenceGrant pairs redundant. Tracked in Loki Thalamus.
