### PR TITLE
fix(bootstrap): unblock homelab rebuild — rdctl compound cmd, Gitea HEAD ref, Traefik CRD conflict

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -550,7 +550,13 @@ echo "⏳ Waiting for Traefik to become ready..."
 kubectl rollout status deployment/traefik -n kube-system --timeout=120s || { echo "❌ Traefik failed to start."; exit 1; }
 
 echo "   Verifying Gateway API CRDs (installed by Traefik chart)..."
-kubectl wait --for=condition=established --timeout=30s crd/gatewayclasses.gateway.networking.k8s.io || { echo "❌ Gateway API CRDs missing after Traefik install"; exit 1; }
+# Wait on the three CRDs the downstream Vegvísir stack actually consumes:
+# GatewayClass + Gateway + HTTPRoute. The chart could partially install
+# (e.g. version skew, hook failure) and a single-CRD check would miss it.
+kubectl wait --for=condition=established --timeout=30s \
+    crd/gatewayclasses.gateway.networking.k8s.io \
+    crd/gateways.gateway.networking.k8s.io \
+    crd/httproutes.gateway.networking.k8s.io || { echo "❌ Gateway API CRDs missing after Traefik install"; exit 1; }
 echo "✅ Traefik Installed (Gateway API + IngressRoute CRDs available)."
 
 # --- Step 2.7: Install Crossplane Providers + Functions (Layer 2.7) ---

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -109,7 +109,9 @@ if [[ "$TARGET" == "homelab" ]] && command -v rdctl &> /dev/null; then
     # Check for iscsiadm (required for Longhorn)
     if ! rdctl shell which iscsiadm >/dev/null 2>&1; then
         echo "⚠️  'iscsiadm' missing in Rancher Desktop VM. Installing open-iscsi..."
-        rdctl shell "sudo apk update && sudo apk add open-iscsi && sudo rc-service iscsid start"
+        # `rdctl shell` invokes commands via nsenter, not a shell — so compound
+        # commands (&&, |, ;) must be wrapped in `sh -c` to be parsed.
+        rdctl shell sh -c "sudo apk update && sudo apk add open-iscsi && sudo rc-service iscsid start"
         echo "✅ Installed open-iscsi."
     else
          echo "✅ 'iscsiadm' found in VM."
@@ -327,10 +329,16 @@ create_gitea_repo() {
         # killing the retry loop on transport-level curl failures (DNS,
         # TCP refusal, TLS handshake) — those are exactly the cases the
         # retry exists to cover.
+        # `auto_init: true` creates an initial commit on `main` and sets the
+        # repo's HEAD symbolic ref to it. Without auto-init, a fresh repo has
+        # no HEAD ref — our later `git push --force` creates `refs/heads/main`
+        # but HEAD remains unresolved, and ArgoCD apps using `targetRevision:
+        # HEAD` fail with `unable to resolve 'HEAD' to a commit SHA`. The
+        # force-push later in the script overwrites the auto-init commit.
         RESPONSE=$(curl -s -u "$GITEA_USER:$GITEA_PASS" \
           -X POST "$GITEA_API_URL/api/v1/user/repos" \
           -H "Content-Type: application/json" \
-          -d "{\"name\": \"$repo_name\", \"private\": false}" || true)
+          -d "{\"name\": \"$repo_name\", \"private\": false, \"auto_init\": true, \"default_branch\": \"main\"}" || true)
 
         # Check if response contains a valid repo (has "clone_url") or already-exists error
         if echo "$RESPONSE" | grep -q '"clone_url"'; then
@@ -480,14 +488,13 @@ else
     echo "   Observability stack will not be deployed until Heimdall is available."
 fi
 
-# --- Step 2.5: Install Gateway API (Layer 2.5) ---
-echo "🚪 [Layer 2.5] Installing Gateway API CRDs..."
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
-
-echo "   Verifying Gateway API CRDs..."
-kubectl wait --for=condition=established --timeout=30s crd/gatewayclasses.gateway.networking.k8s.io || { echo "❌ Failed to install Gateway API CRDs"; exit 1; }
-echo "✅ Gateway API CRDs installed."
-
+# --- Step 2.5: Install Crossplane Core (Layer 2.5) ---
+# Gateway API CRDs were installed here in earlier versions, but Traefik chart
+# 38+ bundles its own copy alongside IngressRoute/Middleware CRDs. Applying
+# them ourselves with `kubectl apply` (client-side, field-manager
+# `kubectl-client-side-apply`) caused a field-manager conflict on first
+# `helm install traefik`. We now let the Traefik chart in Layer 2.6 install
+# the Gateway API CRDs; the verify step moves with them.
 echo "✈️ [Layer 2.5] Installing Crossplane Core..."
 helm repo add crossplane-stable https://charts.crossplane.io/stable >/dev/null 2>&1
 helm repo update
@@ -541,7 +548,10 @@ helm upgrade --install traefik traefik/traefik \
 
 echo "⏳ Waiting for Traefik to become ready..."
 kubectl rollout status deployment/traefik -n kube-system --timeout=120s || { echo "❌ Traefik failed to start."; exit 1; }
-echo "✅ Traefik Installed (IngressRoute CRDs now available)."
+
+echo "   Verifying Gateway API CRDs (installed by Traefik chart)..."
+kubectl wait --for=condition=established --timeout=30s crd/gatewayclasses.gateway.networking.k8s.io || { echo "❌ Gateway API CRDs missing after Traefik install"; exit 1; }
+echo "✅ Traefik Installed (Gateway API + IngressRoute CRDs available)."
 
 # --- Step 2.7: Install Crossplane Providers + Functions (Layer 2.7) ---
 # Pre-install providers so their CRDs (ProviderConfig, etc.) exist before ArgoCD tries to sync.

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -38,13 +38,13 @@ kubectl get secret -n gitea gitea-admin-credentials \
   -o jsonpath='{.data.password}' | base64 --decode
 ```
 
-### Layer 2.5 — Gateway API CRDs + Crossplane Core
-- Installs **Gateway API CRDs** (required before Traefik's GatewayClass can register)
+### Layer 2.5 — Crossplane Core
 - Installs **Crossplane Core** (CRDs must exist before ArgoCD syncs ProviderConfigs)
 
 ### Layer 2.6 — Traefik (pre-ArgoCD)
 - Installs **Traefik** via Helm into `kube-system`
-- Registers `IngressRoute` CRDs needed by any ArgoCD-managed IngressRoute resources
+- Registers `IngressRoute`/`Middleware`/etc. CRDs needed by ArgoCD-managed resources
+- Installs **Gateway API CRDs** (bundled by Traefik chart 38+) — verified post-install
 - Sets `gateway.enabled=false` — the Gateway resource is owned by Vegvísir (Nidavellir)
 - On GKE: provisions the LoadBalancer service (source of the cluster's external IP)
 
@@ -211,8 +211,8 @@ credentials through OpenBAO once it ships in Nidavellir.
 graph TD
     Local[Local Machine] -->|gke-provision.sh| L1[L1: GKE Cluster]
     Local -->|bootstrap.sh| L2[L2: Seed Gitea]
-    L2 --> L25[L2.5: Gateway API CRDs + Crossplane]
-    L25 --> L26[L2.6: Traefik]
+    L2 --> L25[L2.5: Crossplane Core]
+    L25 --> L26[L2.6: Traefik + Gateway API CRDs]
     L26 --> L27[L2.7: Crossplane Providers]
     L27 --> L28[L2.8: ProviderConfigs]
     L28 --> L3[L3: ArgoCD]

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -39,9 +39,11 @@ kubectl get secret -n gitea gitea-admin-credentials \
 ```
 
 ### Layer 2.5 — Crossplane Core
+
 - Installs **Crossplane Core** (CRDs must exist before ArgoCD syncs ProviderConfigs)
 
 ### Layer 2.6 — Traefik (pre-ArgoCD)
+
 - Installs **Traefik** via Helm into `kube-system`
 - Registers `IngressRoute`/`Middleware`/etc. CRDs needed by ArgoCD-managed resources
 - Installs **Gateway API CRDs** (bundled by Traefik chart 38+) — verified post-install


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://github.com/SiliconSaga/yggdrasil/blob/main/docs/gdd/index.md).

## Summary

A planned homelab rebuild (heimdall Phase 1 validation, 2026-05-20) surfaced three independent bootstrap.sh bugs in one fresh Rancher Desktop k3s pass. Each blocked the script before reaching the next layer; each is a small, contained fix.

- **`rdctl shell` compound command** — `rdctl shell` invokes argv via `nsenter` directly with no shell parsing, so the `apk update && apk add && rc-service` chain was rejected (`can't execute '...'`). Wrap in `sh -c "..."`.
- **Gitea-created repos lack a HEAD symbolic ref** — `create_gitea_repo` POSTs without `auto_init`, so the repo starts empty. Subsequent `git push --force` creates `refs/heads/main` but the symbolic HEAD ref stays unset; `git ls-remote ... HEAD` returns empty and every ArgoCD app whose `targetRevision: HEAD` (root-app, nidavellir, garage, the nordri app-of-apps) fails with `unable to resolve 'HEAD' to a commit SHA`. Bootstrap reports success but nothing actually syncs. Fix: pass `auto_init: true, default_branch: "main"` in the create body — Gitea writes an initial commit on `main`, HEAD resolves to it, and the later force-push overwrites the auto-init commit cleanly.
- **Traefik chart 38+ Gateway API CRD field-manager conflict** — Layer 2.5 pre-applied the upstream Gateway API CRDs with `kubectl apply` (field-manager `kubectl-client-side-apply`); Traefik chart 38.0.1 bundles its own copy and refuses to install (`conflict with "kubectl-client-side-apply" using apiextensions.k8s.io/v1: .spec.versions / .metadata.annotations.gateway.networking.k8s.io/bundle-version`). Simplest fix: stop applying the Gateway API CRDs ourselves at Layer 2.5 and let the Traefik chart in Layer 2.6 install them; verify step moves with them. Nothing between 2.5 and 2.6 needs Gateway CRDs (Crossplane Core doesn't), so ordering is preserved.

## Test plan

- [x] **Pre-fix manual workarounds** (one cluster cycle, with three runs to surface each issue) — rebuild succeeded once the workarounds were applied. Phase 1 PR #4 content validated on the resulting cluster (PrometheusRule `heimdall-self-health` with pvc-fill + prometheus-health groups; Loki `retention_period: 7d`).
- [x] **Post-fix end-to-end clean run** (one cluster cycle, single `./bootstrap.sh homelab` call) — no manual intervention, all ArgoCD apps synced, Garage init completed inline, Velero credentials wired, PR #4 still validates (PrometheusRule + 7d retention).

## Related

- Unblocks heimdall PR #4 validation flow (no link from this PR).
