### PR TITLE
skill: add argocd-gitops + crossplane-compositions (port from yggdrasil per revised taxonomy)

### DIFF
--- a/.agent/skills/argocd-gitops/SKILL.md
+++ b/.agent/skills/argocd-gitops/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: argocd-gitops
+description: Use when writing or debugging vanilla open-source ArgoCD — bootstrapping with the CRD chicken-and-egg problem (sync waves + `SkipDryRunOnMissingResource=true` + `ServerSideApply=true`), app-of-apps patterns and their parent-prune footgun, applying changes to `selfHeal: true` Applications (test through Git, NOT `kubectl apply`/edit), patching Helm chart values via Kustomize `helmCharts`, `ServerSideApply` for >262KB CRDs (and why `Replace=true` is the wrong escape hatch), stale-operation recovery, and hard-refreshing a Git-cache miss. NOT Grafana-managed alerting or Argo Rollouts.
+---
+
+# argocd-gitops
+
+## Overview
+
+ArgoCD's mental model is "Git is the source of truth, the controller reconciles the cluster to match." Almost every operational pain comes from **fighting that model** — editing the live cluster while `selfHeal: true` is on, packing too-large CRDs through client-side apply, racing sync waves against asynchronous readiness (provider CRDs), or pruning a parent Application's directory without realizing it cascades. The skill is mostly: how the model expects you to act, and where the model bites you.
+
+## When to Use
+
+- Bootstrapping a fresh ArgoCD on k3d/k3s/cloud K8s.
+- Application stuck `OutOfSync` / `Degraded` / `Progressing` longer than expected.
+- Applying a config change to a `selfHeal: true` Application.
+- Apps whose CRDs come from sibling Apps in the same app-of-apps (CRD chicken-and-egg).
+- Operator CRDs failing to apply with `metadata.annotations: Too long`.
+- ArgoCD shows `Synced` but the live cluster doesn't reflect your last Git push.
+
+NOT for Grafana-managed alerting (`alerting-irm` in grafana/skills), Argo Rollouts (separate project), or per-Crossplane gotchas (see `crossplane-compositions`).
+
+## Quick Reference
+
+| Goal | Pattern | Gotcha |
+|------|---------|--------|
+| Change a live Application's config | Edit Git → push → `argocd app sync <name>` (or wait for poll) | **NEVER** `kubectl apply`/edit on live resources of a `selfHeal: true` Application — the controller reverts within minutes. |
+| App references a CRD that a sibling App installs | `syncOptions: [ServerSideApply=true, SkipDryRunOnMissingResource=true]` + `retry.backoff` + sync waves | Sync waves order *sync start*, not "wait until Healthy." Retry is the actual safety net. |
+| CRDs exceed 262 KB annotation limit | `syncOptions: [ServerSideApply=true]` | `Replace=true` is the WRONG escape hatch — it bypasses SSA field ownership and breaks everything downstream that relies on it. |
+| Patch a Helm chart value that isn't in `values.yaml` | Kustomize `helmCharts` + JSON6902 `patches:`; ArgoCD needs `kustomize.buildOptions: --enable-helm` in `argocd-cm` | Helm-native overrides survive chart upgrades; structural patches break when the manifest tree shifts — prefer values if exposed. |
+| Force ArgoCD to re-read Git (webhook missed) | `kubectl annotate application <name> argocd.argoproj.io/refresh=hard --overwrite` | Plain `refresh` recomputes diff against cached manifests; `hard-refresh` re-clones. For "webhook missed" → `hard`. |
+| Per-resource sync option override | `argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true` annotation on the resource manifest | Fine-grained when only some resources in an App need a tweak. |
+
+## "Test Through Git" — the One Rule
+
+**With `selfHeal: true`, editing the live cluster does NOT change the cluster.** It changes it for ~3 minutes, then the controller reconciles back to Git. Examples that bite:
+
+- `kubectl scale deployment/traefik --replicas=3` → 3min later you're back at 2 (often during the exact incident you scaled for).
+- `kubectl edit` on an `Application`'s spec → controller overwrites from Git source on next poll.
+- "Edit Live Manifest" in the ArgoCD UI → same fate.
+
+**Right way (always):** change Git → push → optionally `argocd app sync` to skip the wait. If you genuinely need an imperative override during an incident:
+
+```bash
+# Disable selfHeal, scale, commit Git, re-enable selfHeal.
+kubectl -n argocd patch application <app> --type merge \
+  -p '{"spec":{"syncPolicy":{"automated":{"selfHeal":false,"prune":true}}}}'
+kubectl -n <ns> scale deployment/<name> --replicas=N
+# ... commit + push the change to Git ...
+kubectl -n argocd patch application <app> --type merge \
+  -p '{"spec":{"syncPolicy":{"automated":{"selfHeal":true,"prune":true}}}}'
+```
+
+Commit the Git change **within the incident window** or your next post-mortem will surface the drift.
+
+(For Crossplane Compositions specifically — `kubectl apply` over a GitOps-managed Composition triggers a flapping war. See `crossplane-compositions` → "Test Through GitOps".)
+
+## CRD Chicken-and-Egg (Bootstrap)
+
+App B uses an `IngressRoute`; App A (Traefik) installs the CRD. They're in the same app-of-apps. App B's plan-time dry-run fails because the CRD doesn't exist yet on the API server.
+
+**Three-part fix** (use all three on consumer Apps):
+
+```yaml
+syncPolicy:
+  syncOptions:
+    - ServerSideApply=true              # SSA tolerates unknown fields better than client-side
+    - SkipDryRunOnMissingResource=true  # the actual fix — skip dry-run for unknown kinds
+    - CreateNamespace=true
+  retry:
+    limit: 10
+    backoff: { duration: 10s, factor: 2, maxDuration: 5m }
+```
+
+Plus **sync waves** to start the CRD-provider Apps first:
+
+```yaml
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: "-5"   # Traefik, Crossplane core, Percona operator CRDs
+    # later waves: 0 (Crossplane Providers), 5 (ProviderConfigs), 10 (workload consumers)
+```
+
+**Caveats:**
+- Sync waves order *sync starts*, not "wait until Healthy." For "wait until Provider is Healthy then apply ProviderConfig" use a `PreSync` Hook + a Job that polls `kubectl wait --for=condition=Healthy`. The simpler pattern is to let retry-with-backoff converge.
+- `ApplyOutOfSyncOnly=true` is fine for steady-state but can mask first-sync ordering bugs. Leave it off during initial bootstrap.
+
+## ServerSideApply for Large CRDs
+
+Operator CRDs (Percona, Strimzi, valkey-operator, etc.) often exceed the 262144-byte annotation limit:
+
+```text
+metadata.annotations: Too long: must have at most 262144 bytes
+```
+
+`kubectl apply` packs the full manifest into `metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"]`. SSA stores field ownership in `metadata.managedFields` (no annotation-size limit). Set `ServerSideApply=true` on every Application that installs operator CRDs.
+
+**Why `Replace=true` is the wrong fix:** it bypasses SSA's field ownership entirely. It works *once*, but every subsequent reconcile (yours OR anyone else's that touches the resource) breaks field ownership, and Kustomize/Helm-rendered patches will fight provider-kubernetes or other controllers. Always prefer `ServerSideApply=true` over `Replace=true`.
+
+## Patching Helm Chart Values That Aren't Exposed
+
+When a chart hardcodes a value (e.g. Percona PG operator's `runAsNonRoot: true` which breaks Rancher Desktop / strict PSA), use Kustomize `helmCharts` to render the chart and JSON6902 to patch the rendered manifest:
+
+```yaml
+# kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: <ns>
+helmCharts:
+  - name: pg-operator
+    repo: https://percona.github.io/percona-helm-charts/
+    version: 2.4.1
+    releaseName: percona-pg
+    namespace: <ns>
+    includeCRDs: true              # REQUIRED — Kustomize skips Helm CRDs by default
+    valuesInline:
+      watchAllNamespaces: true
+patches:
+  - target: { kind: Deployment, name: percona-pg-operator }
+    patch: |
+      - op: replace
+        path: /spec/template/spec/containers/0/securityContext/runAsNonRoot
+        value: false
+```
+
+Then in `argocd-cm`:
+
+```yaml
+data:
+  kustomize.buildOptions: "--enable-helm"
+```
+
+The ArgoCD Application points at the directory containing `kustomization.yaml` (Kustomize source, not Helm).
+
+## App-of-Apps Footguns
+
+- **Parent prune cascades.** A parent Application with `prune: true` and a `path:` directory of child Application manifests: **deleting a child's manifest from Git → next sync prunes the child Application → child's `resources-finalizer` cascades to all live resources it owned**. A "small cleanup PR" can take out a production workload. Mitigate: use `prune: false` on the parent OR move children to explicit `resources` lists OR add `argocd.argoproj.io/sync-options: Prune=false` annotations on individual child resources.
+- **Recursive directory mode.** `source.directory: { recurse: true }` is convenient but means *any* YAML in the tree becomes managed. Stray `*.yaml` notes or backup files become Applications.
+- **Resource hook ordering** (`PreSync`, `Sync`, `PostSync`, `SyncFail`) runs within each Application's sync — they don't cross Application boundaries. Use sync waves for cross-Application ordering.
+
+## Recovery Cookbook
+
+### Stuck sync (`operationState.phase: Running` for ages)
+
+```bash
+# Preferred — clean terminate via CLI.
+argocd app terminate-op <app>
+
+# Without the CLI:
+kubectl -n argocd patch application <app> --type merge -p '{"operation": null}'
+
+# Last resort — controller is wedged; patch the status subresource:
+kubectl -n argocd patch application <app> --type merge --subresource=status \
+  -p '{"status":{"operationState":{"phase":"Failed","message":"manually cleared"}}}'
+
+# Then re-sync
+argocd app sync <app> --prune
+```
+
+Never `kubectl delete application` to "reset" — the `resources-finalizer` cascades to your live workloads.
+
+### Webhook missed / cache stale
+
+```bash
+kubectl annotate application <app> -n argocd argocd.argoproj.io/refresh=hard --overwrite
+argocd app sync <app>          # if it's OutOfSync after refresh
+```
+
+If the entire repo cache is suspect (e.g. someone force-pushed `main`):
+
+```bash
+kubectl -n argocd rollout restart deployment/argocd-repo-server
+```
+
+## Common Mistakes
+
+- **`kubectl edit` / `kubectl apply` over a `selfHeal: true` Application's resources** → reverts within minutes. Change Git instead.
+- **`kubectl delete application` to "start over"** → `resources-finalizer` cascades, deletes live workloads.
+- **Removing a child Application's YAML from a parent's directory while `prune: true`** → child + all its live resources deleted on next sync.
+- **`Replace=true` to bypass the 262KB annotation limit** → wrong fix; breaks SSA field ownership. Use `ServerSideApply=true`.
+- **Forgetting `includeCRDs: true`** in Kustomize `helmCharts` → operator pods crash looking for their own CRDs.
+- **Forgetting `kustomize.buildOptions: --enable-helm`** in `argocd-cm` → Kustomize-with-Helm sources silently render without the chart.
+- **Treating sync waves as readiness gates** → waves order sync *starts*, not "wait until Healthy." Use retry + backoff, or `PreSync` Hooks polling `kubectl wait`.
+
+## Portable Shell Scripts (Bootstrap-Adjacent)
+
+```bash
+# Anchor every path to the script's own dir, regardless of cwd or sourcing.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+# Portable in-place sed (works on GNU + BSD). Or just use yq for YAML.
+sed -i.bak 's/old/new/g' file && rm -f file.bak
+# Or:
+yq -i '.replicas = 3' values.yaml
+```
+
+`BASH_SOURCE[0]` over `$0` matters: when sourced, `$0` is the shell name.
+
+## Sources
+
+- [ArgoCD docs](https://argo-cd.readthedocs.io/en/stable/)
+- [Sync options](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-options/) — `ServerSideApply`, `SkipDryRunOnMissingResource`, etc.
+- [Sync waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/)
+- [Resource hooks](https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/) — `PreSync`/`PostSync`/`SyncFail`
+- See sibling skill `crossplane-compositions` (test-through-GitOps applied to Crossplane). Cross-component refs: Heimdall's `kube-prometheus-stack` (large CRD pattern in practice), root `kuttl-testing` (end-to-end Application convergence testing), and the realm's `siliconsaga-stack` skill for the in-cluster seed-Gitea + re-hydrate workflow specific to this realm.

--- a/.agent/skills/argocd-gitops/SKILL.md
+++ b/.agent/skills/argocd-gitops/SKILL.md
@@ -179,7 +179,7 @@ kubectl -n argocd rollout restart deployment/argocd-repo-server
 - **Removing a child Application's YAML from a parent's directory while `prune: true`** → child + all its live resources deleted on next sync.
 - **`Replace=true` to bypass the 262KB annotation limit** → wrong fix; breaks SSA field ownership. Use `ServerSideApply=true`.
 - **Forgetting `includeCRDs: true`** in Kustomize `helmCharts` → operator pods crash looking for their own CRDs.
-- **Forgetting `kustomize.buildOptions: --enable-helm`** in `argocd-cm` → Kustomize-with-Helm sources silently render without the chart.
+- **Forgetting `kustomize.buildOptions: --enable-helm`** in `argocd-cm` when a kustomization uses `helmCharts:` → manifest generation fails with an explicit "must specify --enable-helm" error and the sync errors out. Not silent — but easy to misdiagnose as a Kustomize bug if you don't know the ArgoCD-side knob exists.
 - **Treating sync waves as readiness gates** → waves order sync *starts*, not "wait until Healthy." Use retry + backoff, or `PreSync` Hooks polling `kubectl wait`.
 
 ## Portable Shell Scripts (Bootstrap-Adjacent)

--- a/.agent/skills/crossplane-compositions/SKILL.md
+++ b/.agent/skills/crossplane-compositions/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: crossplane-compositions
+description: Use when writing or debugging Crossplane v1/v2 Compositions (Pipeline mode with function-go-templating + function-environment-configs + provider-kubernetes), validating offline with `crossplane render`/`beta validate`, debugging Synced-but-not-Ready claims, migrating Deployment strategy on a live cluster (the SSA-Recreate trap), recognizing CompositionRevision flapping (GitOps-managed Composition tell, stale-revision pinning, mutating-webhook fights), or configuring operators that need cluster-wide namespace watching.
+---
+
+# crossplane-compositions
+
+## Overview
+
+Crossplane Compositions in Pipeline mode have a small, stable set of integration gotchas that bite the same way every time: the readiness-via-CEL-on-`Object` pattern, the `function-environment-configs` context shape, validating without a cluster, and the live-mutation traps when you change a managed resource that Kubernetes treats as semi-immutable (`Deployment.strategy`), test by `kubectl apply`ing over a GitOps controller, or share a Composition with someone else who keeps rewriting it.
+
+## When to Use
+
+- Writing a Pipeline Composition (`function-go-templating` + `function-environment-configs` + `provider-kubernetes` + `function-auto-ready`).
+- Claim is `Synced=True Ready=False` and you need to walk the chain.
+- Changing a Deployment's `strategy.type` in a Composition and the rollout deadlocks or returns `Forbidden`.
+- `CompositionRevision` counter climbs every reconcile cycle for no obvious reason.
+- An operator the Composition deploys only reconciles in its own namespace and your Claim sits Ready=False.
+
+## Quick Reference
+
+| Goal | Pattern | Gotcha |
+|------|---------|--------|
+| Offline-validate a Composition | `crossplane render <xr>.yaml <composition>.yaml <functions>.yaml --extra-resources=<envconfig>.yaml --include-function-results --include-context` | No cluster needed — fastest feedback loop. Pair with `crossplane beta validate <xrd>.yaml -` for schema. |
+| Read EnvironmentConfig in template | `{{- $env := index .context "apiextensions.crossplane.io/environment" -}}` then `$env.data.<key>` | `function-environment-configs` writes the merged map under exactly that context key. |
+| Readiness from live status | `Object.spec.readiness: { policy: DeriveFromCelQuery, celQuery: object.status.availableReplicas >= 1 }` | provider-kubernetes evaluates the CEL against the **observed** object — CEL root variable is `object` (the observed resource). Requires `kubernetes.crossplane.io/v1alpha2` (v1alpha1 doesn't support it). |
+| Single-replica RWO Deployment | `strategy: { type: Recreate }` | Default RollingUpdate deadlocks on Multi-Attach. See Heimdall's `kube-prometheus-stack` skill → "Single-Replica RWO Workloads" and Heimdall's `alertmanager-config` for the same pattern. |
+| Provider setup order | Install providers → `kubectl wait --for=condition=Healthy providers.pkg.crossplane.io --all --timeout=120s` → THEN apply `ProviderConfig`s | Otherwise `no matches for kind ProviderConfig` (CRDs don't exist yet). |
+| Operator that watches all namespaces | Use the operator's boolean (e.g. `--set watchAllNamespaces=true`), NOT `--set watchNamespace=""` | Helm `--set` silently ignores empty strings → operator only watches its own namespace → Claim stuck Synced=True Ready=False forever. |
+| CRD field shape | `kubectl explain <kind>.spec.<path>` | Don't guess `spec.instances.containers` vs `spec.instances.initContainer`; the API server has the truth. |
+| Testing | kuttl for end-to-end (Claim→Ready) verification | See root `kuttl-testing` skill — `--config kuttl-test.yaml` matters. |
+
+## CEL Readiness Failure Modes
+
+`object.status.<field>` throws `no such key: status` if the operator hasn't written **any** status yet — transient at first, **permanent** if the operator isn't watching the claim's namespace.
+
+**Diagnosis rule:** if CEL readiness fails AND no pods are being created in the claim's namespace, the operator isn't watching. See the `watchAllNamespaces` row above.
+
+## Debugging `Synced=True Ready=False`
+
+Walk top-down. The contradiction is the clue — at every level ask "what does this say about the level above and below?"
+
+```bash
+# 1. XR's view + which composed resources report not-Ready.
+kubectl get <xr-kind> <claim-name> -o yaml | yq '.status'
+kubectl describe <xr-kind> <claim-name>
+
+# 2. Each composed Object — Synced = "Apply succeeded"; Ready = readinessPolicy result.
+kubectl get objects.kubernetes.crossplane.io -l crossplane.io/composite=<xr-name>
+kubectl describe object <xr-name>-<resource-name>
+
+# 3. The live K8s resource the Object manages.
+kubectl -n <ns> get deploy <name> -o yaml | yq '.status'
+kubectl -n <ns> describe pod -l <selector>
+kubectl -n <ns> get events --sort-by=.lastTimestamp | tail -30
+
+# 4. Provider-kubernetes — does it actually see the live resource?
+kubectl -n crossplane-system logs deploy/provider-kubernetes-... | grep <xr-name>
+```
+
+Most-common root causes: PVC `Pending` (wrong/missing `storageClass`), `ImagePullBackOff`, the operator-not-watching pattern.
+
+## Deployment Strategy Migration on a Live Cluster
+
+When you change a Composition from `strategy.type: RollingUpdate` → `Recreate`, the apply fails with:
+
+```text
+Deployment "X" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy.type is 'Recreate'
+```
+
+The old defaulted `rollingUpdate: { maxSurge, maxUnavailable }` block is still in the live spec, and the API forbids it under `type: Recreate`. The Object goes `Synced=False`; the Deployment keeps running with the old strategy — the migration silently doesn't happen.
+
+**Two fixes — pick by blast radius:**
+
+```bash
+# Surgical: strip the orphan rollingUpdate block in place. Pod keeps running; Crossplane reconciles cleanly into Recreate on next pass.
+kubectl -n <ns> patch deployment <name> --type=json \
+  -p='[{"op":"remove","path":"/spec/strategy/rollingUpdate"}]'
+
+# Nuclear: delete the live Deployment; provider-kubernetes recreates it from the manifest cleanly with type: Recreate.
+kubectl -n <ns> delete deployment <name>
+```
+
+The nuclear option is what we used on GKE during the ntfy rollout — works every time but causes a brief outage. The surgical patch keeps the pod up.
+
+## "Test Through GitOps" — Don't `kubectl apply` Over a Managed Composition
+
+If a Composition (or any Crossplane resource) is managed by ArgoCD/Flux, a `kubectl apply` to test changes triggers a **flapping war**: your apply → GitOps self-heal reverts → next reconcile re-applies → CompositionRevision counter increments every cycle, composed resources oscillate. Test through the git source (push to the seed-gitea, hard-refresh the app); source of truth wins.
+
+`managedFields` names the writers — diagnostic for who's fighting whom:
+
+```bash
+kubectl get composition <name> -o yaml | yq '.metadata.managedFields[].manager'
+# Both `argocd-controller` AND `crossplane` writing the Composition = your flap.
+```
+
+(The SiliconSaga re-hydrate workflow — push to in-cluster seed-gitea via `update-embedded-git.sh <env>` — lives in the realm's `siliconsaga-stack` skill.)
+
+## CompositionRevision Flapping — Three Causes
+
+1. **GitOps controller fighting Crossplane** (above — the usual case).
+2. **Mutating admission webhook** (Istio/Linkerd sidecar injector, Kyverno policy, PSA defaulter) adds fields to the composed resource that aren't in your manifest. Crossplane patches them out → webhook re-injects on next admission → composed object flaps; Object's `Synced` flips. `kubectl get mutatingwebhookconfigurations` + the live resource's `managedFields`.
+3. **Stale `compositionUpdatePolicy: Automatic` adopting the wrong revision.** Automatic picks the revision with the highest `spec.revision` number. If a stale higher-numbered revision lingers (e.g. messy bootstrap history where the Composition was overwritten back and forth), the XR stays pinned to old content even after you apply new. We hit this on a homelab bootstrap.
+
+   ```bash
+   # If numbers don't match creation-time ordering, delete the stale higher one.
+   kubectl get compositionrevision -l crossplane.io/composition-name=<name>
+   kubectl delete compositionrevision <stale-name>
+   ```
+
+## Common Mistakes
+
+- **`kubectl apply` over a GitOps-managed Composition** → flapping war. Test through the git source instead.
+- **Changing `strategy.type` to Recreate via Composition update without clearing `rollingUpdate`** → `Forbidden` API error, Object Synced=False, live Deployment unchanged. Patch or delete.
+- **`--set watchNamespace=""`** on a Helm-installed operator → silently no-ops, operator only watches own namespace, Claim never goes Ready.
+- **CEL query on `status.<field>` before the operator writes status** → transient `no such key: status`. If permanent: operator isn't watching the claim's namespace.
+- **v1alpha1 `Object` with `readiness: { policy: DeriveFromCelQuery }`** → not supported. Use `kubernetes.crossplane.io/v1alpha2`.
+- **Applying `ProviderConfig` before the Provider is `Healthy`** → `no matches for kind`. `kubectl wait --for=condition=Healthy providers.pkg.crossplane.io --all --timeout=120s` first.
+- **Default operator security context clashes** (Rancher Desktop, strict PSA) — `runAsNonRoot` errors. Override in the Composition manifest (e.g. `initContainer.containerSecurityContext.runAsNonRoot: false`).
+- **XRD v1 deprecation warning** — cosmetic; migrate to v2 when ready, v1 still works.
+
+## Implementation Sketch
+
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: <name>-default
+spec:
+  compositeTypeRef: { apiVersion: ..., kind: X... }
+  mode: Pipeline
+  pipeline:
+    - step: load-environment
+      functionRef: { name: function-environment-configs }
+      input:
+        apiVersion: environmentconfigs.fn.crossplane.io/v1beta1
+        kind: Input
+        spec:
+          environmentConfigs:
+            - { type: Reference, ref: { name: cluster-identity } }
+
+    - step: render-resources
+      functionRef: { name: function-go-templating }
+      input:
+        apiVersion: gotemplating.fn.crossplane.io/v1beta1
+        kind: GoTemplate
+        source: Inline
+        inline:
+          template: |
+            {{- $env := index .context "apiextensions.crossplane.io/environment" -}}
+            ---
+            apiVersion: kubernetes.crossplane.io/v1alpha2
+            kind: Object
+            metadata:
+              annotations:
+                gotemplating.fn.crossplane.io/composition-resource-name: my-deployment
+              name: {{ .observed.composite.resource.metadata.name }}-deployment
+            spec:
+              readiness:
+                policy: DeriveFromCelQuery
+                celQuery: object.status.availableReplicas >= 1
+              forProvider:
+                manifest:
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  spec:
+                    strategy:
+                      type: Recreate   # if mounting a single-replica RWO PVC
+                    # ...
+
+    - step: auto-ready
+      functionRef: { name: function-auto-ready }
+```
+
+## Sources
+
+- [Crossplane Compositions](https://docs.crossplane.io/latest/concepts/compositions/)
+- [`crossplane render`](https://docs.crossplane.io/latest/cli/command-reference/#render) + [`crossplane beta validate`](https://docs.crossplane.io/latest/cli/command-reference/#beta-validate)
+- [function-go-templating](https://github.com/crossplane-contrib/function-go-templating) + [function-environment-configs](https://github.com/crossplane-contrib/function-environment-configs)
+- [provider-kubernetes `Object`](https://github.com/crossplane-contrib/provider-kubernetes) — v1alpha2 for `DeriveFromCelQuery`
+- See sibling skill `argocd-gitops` (test-through-GitOps applied at the ArgoCD layer). Cross-component refs: Heimdall's `kube-prometheus-stack` (RWO+Recreate, SSA migration applied to a real workload), Heimdall's `alertmanager-config` (same pattern), root `kuttl-testing` (end-to-end Claim→Ready testing), and the realm's `siliconsaga-stack` (re-hydrate-to-test workflow).


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- **Phase 1-revised** of the SiliconSaga skill taxonomy (see realm-siliconsaga PR #6). Ports `argocd-gitops` and `crossplane-compositions` from yggdrasil PRs #81 and #80 into Nordri, which is the component that operates both.
- The first-pass implementation put both at yggdrasil root per "highest applicable tier by capability." After review, the principle was refined to "highest tier where the knowledge is genuinely owned" — ArgoCD and Crossplane are opinionated platform choices Nordri ships and operates, so they belong here. Other components consume the resulting GitOps surface and Composition API, but Nordri is the experts-of-record.
- Content is the review-cleaned version from the source PRs (committed SHAs `a76cc38`, `6fd5378`). Already passed CodeRabbit + Copilot review, including the CEL root-variable consistency fix (#80) and the MD040 fenced-code-block fixes (#80, #81). Cross-component references updated to call out where sibling skills now live.

## Test plan

- [x] Both SKILL.md files render cleanly.
- [x] Cross-component references (`alertmanager-config`, `kube-prometheus-stack`, `kuttl-testing`, `siliconsaga-stack`) point at locations consistent with the revised taxonomy.
- [x] No content lost vs the source yggdrasil PRs — review fixes preserved.

## Related

- **Source:** yggdrasil PRs #80 (`crossplane-compositions`) and #81 (`argocd-gitops`) — to be closed without merging once this PR lands.
- **Design doc:** `realms/realm-siliconsaga/docs/plans/2026-05-30-skill-taxonomy-design.md` (revised in realm-siliconsaga PR #6).
- **Sibling import PR:** Heimdall receives `alertmanager-config` + `kube-prometheus-stack` (ports of yggdrasil #78 and #79) in PR `SiliconSaga/heimdall#7`.
- **Merge order:** independent. Recommended sequence: realm-siliconsaga PR #6 (taxonomy + cleanup) → this PR + the Heimdall import PR (in either order) → close yggdrasil PRs #78–81.
