### PR TITLE
feat(hydrate): vendor-mirror support (history + tags into seed Gitea)

### DIFF
--- a/.agent/skills/crossplane-compositions/SKILL.md
+++ b/.agent/skills/crossplane-compositions/SKILL.md
@@ -21,7 +21,8 @@ Crossplane Compositions in Pipeline mode have a small, stable set of integration
 
 | Goal | Pattern | Gotcha |
 |------|---------|--------|
-| Offline-validate a Composition | `crossplane render <xr>.yaml <composition>.yaml <functions>.yaml --extra-resources=<envconfig>.yaml --include-function-results --include-context` | No cluster needed — fastest feedback loop. Pair with `crossplane beta validate <xrd>.yaml -` for schema. |
+| Offline-validate a Composition | `crossplane render <xr>.yaml <composition>.yaml <functions>.yaml --extra-resources=<envconfig>.yaml --include-function-results --include-context` | No cluster needed — fastest feedback loop. Pair with `crossplane beta validate <xrd>.yaml -` for schema. Render takes an **XR**, not a claim. CLI install: realm `docs/dev-setup.md`. Commit the fixtures (XR + functions + envconfig) under `tests/render/` so the check is repeatable — nidavellir has the reference layout. |
+| Stable names from a Helm `Release` | `values.fullnameOverride: <name>` | The Release MR's name includes the XR's random claim suffix (`myapp-v4ktr-...`), and the chart's workload/Service names inherit it. Any stable consumer-facing reference — a Service URL another component hardcodes, runbook commands, kuttl asserts — needs `fullnameOverride` (or chart equivalent) to pin the rendered names. |
 | Read EnvironmentConfig in template | `{{- $env := index .context "apiextensions.crossplane.io/environment" -}}` then `$env.data.<key>` | `function-environment-configs` writes the merged map under exactly that context key. |
 | Readiness from live status | `Object.spec.readiness: { policy: DeriveFromCelQuery, celQuery: object.status.availableReplicas >= 1 }` | provider-kubernetes evaluates the CEL against the **observed** object — CEL root variable is `object` (the observed resource). Requires `kubernetes.crossplane.io/v1alpha2` (v1alpha1 doesn't support it). |
 | Single-replica RWO Deployment | `strategy: { type: Recreate }` | Default RollingUpdate deadlocks on Multi-Attach. See Heimdall's `kube-prometheus-stack` skill → "Single-Replica RWO Workloads" and Heimdall's `alertmanager-config` for the same pattern. |
@@ -118,6 +119,8 @@ kubectl get composition <name> -o yaml | yq '.metadata.managedFields[].manager'
 - **Applying `ProviderConfig` before the Provider is `Healthy`** → `no matches for kind`. `kubectl wait --for=condition=Healthy providers.pkg.crossplane.io --all --timeout=120s` first.
 - **Default operator security context clashes** (Rancher Desktop, strict PSA) — `runAsNonRoot` errors. Override in the Composition manifest (e.g. `initContainer.containerSecurityContext.runAsNonRoot: false`).
 - **XRD v1 deprecation warning** — cosmetic; migrate to v2 when ready, v1 still works.
+- **Letting the XR suffix leak into Helm-chart workload names.** A `Release` named `{{ XR name }}-myapp` produces pods/Services like `myapp-v4ktr-...` that change whenever the claim is recreated. If anything references those names statically (ESO store URLs, HTTPRoute backendRefs, kuttl asserts, docs), set `fullnameOverride` in the chart values. Caught live in nidavellir's OpenBao composition — heimdall's suffixed workloads are the counter-example where nothing external cares.
+- **Helm values written for an older chart's image shape.** Charts periodically split `image.repository` into `registry` + `repository` (vault/openbao 0.28.x did). Re-setting the old combined form renders `quay.io/quay.io/...`. Check `helm show values` for the deployed chart version before carrying values forward.
 
 ## Implementation Sketch
 

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -368,34 +368,43 @@ else
     echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
 fi
 
-# Vendor mirrors: faithfully mirror the local clone into the seed so an
-# in-cluster app can pin ANY upstream ref — a tag (as keycloak-operator does)
-# OR a branch (a future vendor might). Push every upstream branch as a head
-# plus every tag, with --prune so refs deleted upstream don't linger in the
-# seed across re-hydrations.
+# Vendor mirrors: mirror the local clone into the seed so an in-cluster app
+# can pin ANY upstream ref — a tag (as keycloak-operator does) OR a branch (a
+# future vendor might). A normal `ws clone` keeps only the default branch as a
+# local head (refs/heads/*) and the rest under refs/remotes/<remote>/*, so we
+# push both: the heads glob carries the default branch reliably, and a loop
+# adds every non-default upstream branch from the remote-tracking namespace
+# (skipping the HEAD symref so we never push a bogus refs/heads/HEAD).
 #
-# A normal `ws clone` keeps non-default branches under refs/remotes/<remote>/*
-# (only the default branch gets a local refs/heads/* entry), so we push from
-# the remote-tracking namespace to capture them all. We drop that namespace's
-# HEAD symref first so the wildcard doesn't try to create a bogus
-# refs/heads/HEAD on the seed; deleting it is harmless to the working clone
-# (git recreates it on the next fetch/pull). This reads from the as-fetched
-# remote-tracking refs (no network at hydrate time) — refresh the mirror with
-# `ws pull <vendor>` to advance it.
+# Heads are pushed WITHOUT --prune on purpose: pruning the heads namespace
+# would try to delete the seed's default branch whenever a branch name isn't
+# in the source set, which Gitea rejects ("default branch cannot be deleted")
+# and fails the whole hydration. Tags DO get --prune — they're the drift-prone
+# refs (a retracted tag should disappear) and tag pruning can't hit that trap.
+# A branch deleted upstream lingers in the ephemeral seed until the next clean
+# bootstrap; nothing pins a deleted branch, so that's acceptable.
 #
-# Not `git push --mirror`: from a non-bare clone it would push the
-# remote-tracking refs verbatim (littering the seed with refs/remotes/*) and
-# carry any refs/pull/* an upstream mirror has.
+# Reads as-fetched remote-tracking refs (no network at hydrate time) — refresh
+# a mirror with `ws pull <vendor>`. Not `git push --mirror`: from a non-bare
+# clone it pushes refs/remotes/* verbatim (littering the seed) and carries any
+# refs/pull/* an upstream mirror has.
 for VENDOR in $VENDOR_MIRRORS; do
     VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
     if [[ -d "$VENDOR_DIR/.git" ]]; then
         echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
         ensure_gitea_repo "$VENDOR"
         VENDOR_REMOTE="$(git -C "$VENDOR_DIR" remote | head -n1)"
-        git -C "$VENDOR_DIR" update-ref -d "refs/remotes/$VENDOR_REMOTE/HEAD" 2>/dev/null || true
-        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" \
-            "refs/remotes/$VENDOR_REMOTE/*:refs/heads/*" \
-            "refs/tags/*:refs/tags/*"
+        VENDOR_SEED="$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git"
+        # Default branch (reliably a local head) + every non-default upstream
+        # branch (remote-tracking, minus the HEAD symref), each mapped to a seed head.
+        VENDOR_REFSPECS=("+refs/heads/*:refs/heads/*")
+        while IFS= read -r _vref; do
+            _vbranch="${_vref#refs/remotes/$VENDOR_REMOTE/}"
+            [[ "$_vbranch" == "HEAD" ]] && continue
+            VENDOR_REFSPECS+=("+$_vref:refs/heads/$_vbranch")
+        done < <(git -C "$VENDOR_DIR" for-each-ref --format='%(refname)' "refs/remotes/$VENDOR_REMOTE")
+        git -C "$VENDOR_DIR" push --force "$VENDOR_SEED" "${VENDOR_REFSPECS[@]}"
+        git -C "$VENDOR_DIR" push --force --prune "$VENDOR_SEED" 'refs/tags/*:refs/tags/*'
         echo "✅ Vendor mirror '$VENDOR' updated."
     else
         echo "⚠️  Vendor mirror '$VENDOR' not cloned at: $VENDOR_DIR"

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -368,29 +368,34 @@ else
     echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
 fi
 
-# Vendor mirrors: push the local clone's heads + tags into the seed so
-# in-cluster apps can pin upstream tags. --prune drops seed refs that no
-# longer exist locally (e.g. a tag retracted upstream and picked up on a
-# re-sync), so the seed copy can't drift past the local clone over repeated
-# hydrations.
+# Vendor mirrors: faithfully mirror the local clone into the seed so an
+# in-cluster app can pin ANY upstream ref — a tag (as keycloak-operator does)
+# OR a branch (a future vendor might). Push every upstream branch as a head
+# plus every tag, with --prune so refs deleted upstream don't linger in the
+# seed across re-hydrations.
 #
-# Heads + tags globs only — deliberately NOT `git push --mirror`: from a
-# non-bare working clone, --mirror pushes the remote-tracking refs
-# (refs/remotes/<remote>/*) verbatim, littering the seed with refs/remotes/*
-# and the HEAD symref rather than clean heads. It would also carry any
-# refs/pull/* an upstream mirror has.
+# A normal `ws clone` keeps non-default branches under refs/remotes/<remote>/*
+# (only the default branch gets a local refs/heads/* entry), so we push from
+# the remote-tracking namespace to capture them all. We drop that namespace's
+# HEAD symref first so the wildcard doesn't try to create a bogus
+# refs/heads/HEAD on the seed; deleting it is harmless to the working clone
+# (git recreates it on the next fetch/pull). This reads from the as-fetched
+# remote-tracking refs (no network at hydrate time) — refresh the mirror with
+# `ws pull <vendor>` to advance it.
 #
-# Scope note: refs/heads/* from a normal `ws clone` is just the default
-# branch — enough to give the seed repo a HEAD. Non-default upstream
-# branches aren't mirrored, because vendor apps pin TAGS (fully mirrored
-# below), not dev branches. If an app ever needs to pin a branch, revisit.
+# Not `git push --mirror`: from a non-bare clone it would push the
+# remote-tracking refs verbatim (littering the seed with refs/remotes/*) and
+# carry any refs/pull/* an upstream mirror has.
 for VENDOR in $VENDOR_MIRRORS; do
     VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
     if [[ -d "$VENDOR_DIR/.git" ]]; then
         echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
         ensure_gitea_repo "$VENDOR"
-        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/heads/*:refs/heads/*'
-        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/tags/*:refs/tags/*'
+        VENDOR_REMOTE="$(git -C "$VENDOR_DIR" remote | head -n1)"
+        git -C "$VENDOR_DIR" update-ref -d "refs/remotes/$VENDOR_REMOTE/HEAD" 2>/dev/null || true
+        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" \
+            "refs/remotes/$VENDOR_REMOTE/*:refs/heads/*" \
+            "refs/tags/*:refs/tags/*"
         echo "✅ Vendor mirror '$VENDOR' updated."
     else
         echo "⚠️  Vendor mirror '$VENDOR' not cloned at: $VENDOR_DIR"

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -390,10 +390,27 @@ fi
 # refs/pull/* an upstream mirror has.
 for VENDOR in $VENDOR_MIRRORS; do
     VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
-    if [[ -d "$VENDOR_DIR/.git" ]]; then
+    # Plumbing check, not `-d .git`: a worktree or submodule has `.git` as a
+    # FILE, which a directory test would wrongly reject as "not cloned".
+    if git -C "$VENDOR_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
         ensure_gitea_repo "$VENDOR"
-        VENDOR_REMOTE="$(git -C "$VENDOR_DIR" remote | head -n1)"
+        # Resolve the source remote robustly. `ws clone` names the remote after
+        # the org (not "origin"), so prefer the checked-out branch's tracking
+        # remote; fall back to the sole remote; warn-and-skip rather than guess
+        # if neither is determinable (picking head -n1 of several could push
+        # from the wrong refs/remotes/* namespace and clobber seed refs).
+        VENDOR_BRANCH="$(git -C "$VENDOR_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        VENDOR_REMOTE=""
+        [[ -n "$VENDOR_BRANCH" ]] && VENDOR_REMOTE="$(git -C "$VENDOR_DIR" config "branch.$VENDOR_BRANCH.remote" 2>/dev/null || true)"
+        if [[ -z "$VENDOR_REMOTE" ]]; then
+            _vr_count="$(git -C "$VENDOR_DIR" remote | grep -c .)"
+            if [[ "$_vr_count" != "1" ]]; then
+                echo "⚠️  Vendor mirror '$VENDOR' has $_vr_count remotes and no tracked upstream — skipping (set a single remote or a tracking branch)." >&2
+                continue
+            fi
+            VENDOR_REMOTE="$(git -C "$VENDOR_DIR" remote)"
+        fi
         VENDOR_SEED="$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git"
         # Default branch (reliably a local head) + every non-default upstream
         # branch (remote-tracking, minus the HEAD symref), each mapped to a seed head.

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -368,16 +368,29 @@ else
     echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
 fi
 
-# Vendor mirrors: push real history + tags from the local clone so
-# in-cluster apps can pin upstream tags. Heads and tags only — never
-# refs/pull/* or other namespaces an upstream mirror may carry.
+# Vendor mirrors: push the local clone's heads + tags into the seed so
+# in-cluster apps can pin upstream tags. --prune drops seed refs that no
+# longer exist locally (e.g. a tag retracted upstream and picked up on a
+# re-sync), so the seed copy can't drift past the local clone over repeated
+# hydrations.
+#
+# Heads + tags globs only — deliberately NOT `git push --mirror`: from a
+# non-bare working clone, --mirror pushes the remote-tracking refs
+# (refs/remotes/<remote>/*) verbatim, littering the seed with refs/remotes/*
+# and the HEAD symref rather than clean heads. It would also carry any
+# refs/pull/* an upstream mirror has.
+#
+# Scope note: refs/heads/* from a normal `ws clone` is just the default
+# branch — enough to give the seed repo a HEAD. Non-default upstream
+# branches aren't mirrored, because vendor apps pin TAGS (fully mirrored
+# below), not dev branches. If an app ever needs to pin a branch, revisit.
 for VENDOR in $VENDOR_MIRRORS; do
     VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
     if [[ -d "$VENDOR_DIR/.git" ]]; then
         echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
         ensure_gitea_repo "$VENDOR"
-        git -C "$VENDOR_DIR" push --force "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/heads/*:refs/heads/*'
-        git -C "$VENDOR_DIR" push --force "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/tags/*:refs/tags/*'
+        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/heads/*:refs/heads/*'
+        git -C "$VENDOR_DIR" push --force --prune "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/tags/*:refs/tags/*'
         echo "✅ Vendor mirror '$VENDOR' updated."
     else
         echo "⚠️  Vendor mirror '$VENDOR' not cloned at: $VENDOR_DIR"

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -72,6 +72,14 @@ NIDAVELLIR_DIR="${NIDAVELLIR_DIR:-$(dirname "$SCRIPT_DIR")/nidavellir}"
 MIMIR_DIR="${MIMIR_DIR:-$(dirname "$SCRIPT_DIR")/mimir}"
 HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 
+# Vendored upstream mirrors (declared in the realm ecosystem.yaml with
+# tier: vendor). Unlike the working-tree repos above — which hydrate as a
+# fresh orphan commit of the local tree — vendor mirrors push their REAL
+# git history and tags, so in-cluster ArgoCD apps can pin exact upstream
+# tags (e.g. keycloak-operator pins targetRevision "26.6.3"). Space-
+# separated list of component dir names under the workspace components/.
+VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
+
 # Resolve Gitea admin credentials.
 #
 # Password priority:  GITEA_PASS env  >  Secret  >  fail with helpful message
@@ -359,6 +367,23 @@ else
     echo "⚠️  Heimdall directory not found at: $HEIMDALL_DIR"
     echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
 fi
+
+# Vendor mirrors: push real history + tags from the local clone so
+# in-cluster apps can pin upstream tags. Heads and tags only — never
+# refs/pull/* or other namespaces an upstream mirror may carry.
+for VENDOR in $VENDOR_MIRRORS; do
+    VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
+    if [[ -d "$VENDOR_DIR/.git" ]]; then
+        echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
+        ensure_gitea_repo "$VENDOR"
+        git -C "$VENDOR_DIR" push --force "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/heads/*:refs/heads/*'
+        git -C "$VENDOR_DIR" push --force "$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git" 'refs/tags/*:refs/tags/*'
+        echo "✅ Vendor mirror '$VENDOR' updated."
+    else
+        echo "⚠️  Vendor mirror '$VENDOR' not cloned at: $VENDOR_DIR"
+        echo "   Run 'ws clone $VENDOR' if apps on this cluster pin it."
+    fi
+done
 
 echo "✅ Configuration Updated."
 echo "🔄 Triggering ArgoCD Sync (Root App)..."


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- `update-embedded-git.sh` learns **vendor mirrors**: components declared `tier: vendor` in the realm ecosystem hydrate by force-pushing the local clone's real heads + tags to the seed Gitea (refspec'd to exclude `refs/pull/*` etc.), unlike the orphan-commit-of-the-working-tree flow used for the maintained repos. That's what lets in-cluster ArgoCD apps pin exact upstream tags — nidavellir's keycloak-operator app pins `26.6.3`.
- Missing clone degrades to a warning with a `ws clone` pointer (matching the sibling repo blocks); list env-overridable via `VENDOR_MIRRORS`.

## Test plan

- [x] Homelab re-hydration pushes the mirror (repo auto-created, tags present in seed Gitea); keycloak-operator app syncs Healthy from `…/keycloak-k8s-resources.git @ 26.6.3`
- [x] sso-demo kuttl acceptance re-run green after the switch

## Related

- Companions: realm-siliconsaga (ecosystem `tier: vendor` entry), SiliconSaga/nidavellir#15 (operator app repoint)
