### PR TITLE
feat(dns): resolve keycloak.localhost in-cluster on homelab

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Nordri exposes substrate patterns that downstream components (Heimdall, Mimir,
     *   **Multi-node homelab / production**: Longhorn (or another distributed storage like Rook-Ceph) is essential since `local-path` doesn't survive node loss. This is a future migration target.
     *   **GKE**: Uses its own CSI driver (Persistent Disk). Longhorn is not needed.
 
+*   **In-cluster `keycloak.localhost`**: On homelab a CoreDNS rewrite lets *pods* resolve `keycloak.localhost` to Traefik, so server-side OIDC flows (e.g. OpenBao's token exchange) can reach Keycloak at its homelab issuer. See **[Resolving keycloak.localhost inside the cluster](docs/keycloak-localhost-coredns.md)**.
 *   **Argonception**: Most YAML files in `apps/` are `kind: Application`. They tell Argo to sync *another* Helm chart (e.g., the official Traefik chart).
 *   **Namespaces**: Any "loose" manifest (like `ClusterIssuer`) applied by the App-of-Apps will default to the `argo` namespace unless explicitly namespaced in the file.
 *   **Values**: Environment-specific values (e.g., LoadBalancer vs NodePort) are injected via the `envs/` directory, which the App-of-Apps or individual Applications reference.

--- a/docs/keycloak-localhost-coredns.md
+++ b/docs/keycloak-localhost-coredns.md
@@ -39,7 +39,7 @@ This rewrite is wrong on GKE, where `keycloak.cmdbee.org` has real public DNS an
 
 The manifest is part of the homelab fundamentals overlay, which the platform app-of-apps points ArgoCD at (path patched to `overlays/homelab` by `bootstrap.sh`). So a fresh homelab bootstrap recreates the `coredns-custom` ConfigMap automatically; there is nothing manual to remember on rebuild.
 
-A GitOps change to this ConfigMap applies **automatically** — CoreDNS's `reload` plugin (enabled in the Corefile) plus kubelet's ConfigMap→volume sync pick up drop-in changes within ~1–2 min, no restart needed (verified 2026-06-30: a second rewrite rule added via `kubectl apply` resolved from a pod without any restart). To *expedite* a change during hands-on work you can force it:
+A GitOps **change** to an existing `coredns-custom` drop-in applies automatically — CoreDNS's `reload` plugin (enabled in the Corefile) plus kubelet's ConfigMap→volume sync pick it up within ~1–2 min, no restart (verified 2026-06-30: a second rewrite rule added to the live CM via `kubectl apply` resolved from a pod without any restart). Two boundary cases still want a nudge: the **first-ever creation** of the ConfigMap on an already-running CoreDNS may need one restart to force the initial re-hash of the newly-populated drop-in, and a from-scratch bootstrap simply loads it at CoreDNS startup (nothing to do). Force any of these immediately with:
 
 ```bash
 kubectl -n kube-system rollout restart deploy/coredns

--- a/docs/keycloak-localhost-coredns.md
+++ b/docs/keycloak-localhost-coredns.md
@@ -1,0 +1,65 @@
+# Resolving `keycloak.localhost` inside the cluster (homelab CoreDNS rewrite)
+
+On homelab, a CoreDNS drop-in rewrites the name `keycloak.localhost` to the in-cluster Traefik Service so that **pods** — not just browsers — can reach Keycloak at its homelab issuer URL. This page explains why that is needed, how the rewrite works, and how to verify it. The manifest is `platform/fundamentals/manifests/coredns-custom-homelab.yaml`, referenced only from the homelab overlay.
+
+## Why it's needed: the OIDC split-horizon problem
+
+Keycloak runs in Hostname-v2 **dynamic** mode (`keycloak/keycloak.yaml`, `hostname.strict: false`). The OIDC `issuer` it advertises follows the request host: `http://keycloak.localhost` on homelab, `https://keycloak.cmdbee.org` on GKE. A pinned hostname would make the issuer unreachable from a homelab browser, so dynamic mode is deliberate.
+
+Browsers resolve any `*.localhost` name to `127.0.0.1` for free (RFC 6761), so the **browser leg** of an OIDC login — the redirect to Keycloak's authorization endpoint — works without any help. The trouble is the **server leg**.
+
+OpenBao's OIDC auth method (the first consumer; it backs leidangr's `scripts/dev-secrets` → `bao login -method=oidc`) derives *every* endpoint — authorization, token, JWKS — from a single discovery document, and it validates the ID token's `iss` claim strictly. There is no "discover here, redirect the browser somewhere else" split the way oauth2-proxy offers (`--insecure-oidc-skip-issuer-verification`, used by the SSO demo). So every actor has to agree on one issuer: `http://keycloak.localhost/realms/<realm>`.
+
+But the OpenBao **pod** performs the authorization-code → token exchange server-to-server, and cluster DNS has no record for `keycloak.localhost` — it is a browser/RFC-6761 convention, not a real DNS zone. Without a rewrite the pod's lookup fails and `bao login -method=oidc` never completes (the browser logs in, then the CLI hangs/errors on the token exchange). The same trap will bite any in-cluster client that has to reach a `*.localhost` homelab service server-side.
+
+## How the rewrite works
+
+k3s ships CoreDNS with two import directives in its Corefile: `import /etc/coredns/custom/*.override` **inside** the `.:53 { … }` server block, and `import /etc/coredns/custom/*.server` at the top level. The CoreDNS Deployment mounts an **optional** ConfigMap named `coredns-custom` (in `kube-system`) at `/etc/coredns/custom`. Any data key ending in `.override` is injected as directives *within* the server block — so we never edit the k3s-managed `coredns` ConfigMap, which k3s would revert on restart.
+
+Our `keycloak.override` key contains:
+
+```
+rewrite stop {
+  name exact keycloak.localhost traefik.kube-system.svc.cluster.local
+  answer auto
+}
+```
+
+- `name exact keycloak.localhost …` rewrites only that one name to the cluster-internal Traefik Service. `exact` keeps the blast radius to a single name — no other `*.localhost` is affected.
+- Traefik already routes the `keycloak.localhost` Host to Keycloak via the `keycloak-localhost` HTTPRoute, so once the pod reaches Traefik on port 80 with that Host header, the request lands on Keycloak.
+- `answer auto` rewrites the response's owner name from `traefik.kube-system.svc.cluster.local` back to `keycloak.localhost`. Without it the A record comes back owned by the Traefik name and a strict resolver (Go, in the OpenBao pod) discards it as a question/answer name mismatch. This is the easy-to-miss part: the bare two-argument `rewrite name … …` form is *not* enough on its own.
+
+## Scope: homelab only
+
+This rewrite is wrong on GKE, where `keycloak.cmdbee.org` has real public DNS and TLS. The manifest is therefore referenced **only** from `platform/fundamentals/overlays/homelab/kustomization.yaml`. The GKE overlay does not include it.
+
+## Deployment and reproducibility
+
+The manifest is part of the homelab fundamentals overlay, which the platform app-of-apps points ArgoCD at (path patched to `overlays/homelab` by `bootstrap.sh`). So a fresh homelab bootstrap recreates the `coredns-custom` ConfigMap automatically; there is nothing manual to remember on rebuild.
+
+CoreDNS does not always re-hash imported drop-ins on its own when the ConfigMap changes, so after a *change* to this file force a reload:
+
+```bash
+kubectl -n kube-system rollout restart deploy/coredns
+```
+
+(First-time creation on a running cluster also wants the restart; a from-scratch bootstrap starts CoreDNS after the ConfigMap exists, so it picks it up on boot.)
+
+## Verify
+
+Resolve the name from inside the OpenBao pod (any pod works — it is cluster-wide DNS):
+
+```bash
+kubectl -n openbao exec openbao-0 -- nslookup keycloak.localhost
+# Name: keycloak.localhost  →  Address: <Traefik ClusterIP>
+```
+
+Then confirm the full HTTP path through Traefik returns Keycloak's discovery document with the `keycloak.localhost` issuer:
+
+```bash
+kubectl -n openbao exec openbao-0 -- \
+  wget -qO- http://keycloak.localhost/realms/siliconsaga/.well-known/openid-configuration
+# "issuer":"http://keycloak.localhost/realms/siliconsaga", …
+```
+
+If the first command resolves but the second hangs or 404s, check that the `keycloak-localhost` HTTPRoute is attached to the Traefik Gateway's `web` listener.

--- a/docs/keycloak-localhost-coredns.md
+++ b/docs/keycloak-localhost-coredns.md
@@ -18,7 +18,7 @@ k3s ships CoreDNS with two import directives in its Corefile: `import /etc/cored
 
 Our `keycloak.override` key contains:
 
-```
+```text
 rewrite stop {
   name exact keycloak.localhost traefik.kube-system.svc.cluster.local
   answer auto

--- a/docs/keycloak-localhost-coredns.md
+++ b/docs/keycloak-localhost-coredns.md
@@ -16,6 +16,8 @@ But the OpenBao **pod** performs the authorization-code → token exchange serve
 
 k3s ships CoreDNS with two import directives in its Corefile: `import /etc/coredns/custom/*.override` **inside** the `.:53 { … }` server block, and `import /etc/coredns/custom/*.server` at the top level. The CoreDNS Deployment mounts an **optional** ConfigMap named `coredns-custom` (in `kube-system`) at `/etc/coredns/custom`. Any data key ending in `.override` is injected as directives *within* the server block — so we never edit the k3s-managed `coredns` ConfigMap, which k3s would revert on restart.
 
+> **Distro portability:** the `coredns-custom` drop-in is a **k3s** convenience — it works on any k3s (Rancher Desktop, k3d, or a manual k3s under Orbstack, etc.). Non-k3s distros (Docker Desktop's built-in Kubernetes, kind) don't ship the `import` line or the optional CM, so they'd need a different CoreDNS patch. GKE needs none of this — it uses real public DNS.
+
 Our `keycloak.override` key contains:
 
 ```text
@@ -37,13 +39,13 @@ This rewrite is wrong on GKE, where `keycloak.cmdbee.org` has real public DNS an
 
 The manifest is part of the homelab fundamentals overlay, which the platform app-of-apps points ArgoCD at (path patched to `overlays/homelab` by `bootstrap.sh`). So a fresh homelab bootstrap recreates the `coredns-custom` ConfigMap automatically; there is nothing manual to remember on rebuild.
 
-CoreDNS does not always re-hash imported drop-ins on its own when the ConfigMap changes, so after a *change* to this file force a reload:
+A GitOps change to this ConfigMap applies **automatically** — CoreDNS's `reload` plugin (enabled in the Corefile) plus kubelet's ConfigMap→volume sync pick up drop-in changes within ~1–2 min, no restart needed (verified 2026-06-30: a second rewrite rule added via `kubectl apply` resolved from a pod without any restart). To *expedite* a change during hands-on work you can force it:
 
 ```bash
 kubectl -n kube-system rollout restart deploy/coredns
 ```
 
-(First-time creation on a running cluster also wants the restart; a from-scratch bootstrap starts CoreDNS after the ConfigMap exists, so it picks it up on boot.)
+Codifying an explicit expedite for the GitOps path (an ArgoCD PostSync hook or Stakater Reloader) is tracked in nordri#20.
 
 ## Verify
 

--- a/platform/fundamentals/manifests/coredns-custom-homelab.yaml
+++ b/platform/fundamentals/manifests/coredns-custom-homelab.yaml
@@ -1,0 +1,64 @@
+# CoreDNS custom drop-in (HOMELAB ONLY) — make keycloak.localhost resolvable
+# from *inside* the cluster.
+#
+# ── Why this exists ────────────────────────────────────────────────────────
+# Keycloak runs in Hostname-v2 *dynamic* mode (keycloak/keycloak.yaml:
+# hostname.strict=false), so the OIDC issuer it advertises follows the request
+# host: `http://keycloak.localhost` on homelab, `https://keycloak.cmdbee.org`
+# on GKE. Browsers resolve `*.localhost` to 127.0.0.1 for free (RFC 6761), so
+# the browser leg of any OIDC login works without help.
+#
+# The problem is the SERVER leg. OpenBao's OIDC auth method (consumed by
+# leidangr's `scripts/dev-secrets` → `bao login -method=oidc`) derives ALL
+# endpoints from a single discovery document and validates the `iss` claim
+# strictly — it has no "discover here, redirect the browser there" split. So
+# every actor must agree on one issuer: `http://keycloak.localhost/realms/...`.
+# But the OpenBao *pod* does the authorization-code → token exchange
+# server-to-server, and cluster DNS has no record for `keycloak.localhost`
+# (it is a browser/RFC-6761 convention, not a real zone). Without this file the
+# token exchange fails with a DNS error and `bao login -method=oidc` never
+# completes. See docs/keycloak-localhost-coredns.md for the full write-up.
+#
+# ── What this does ─────────────────────────────────────────────────────────
+# k3s ships CoreDNS with `import /etc/coredns/custom/*.override` INSIDE the
+# `.:53 { … }` server block (and `*.server` at top level). The coredns
+# Deployment mounts the optional `coredns-custom` ConfigMap at that path, so a
+# key ending in `.override` is injected as directives within the server block —
+# no edit to the k3s-managed `coredns` ConfigMap (which k3s would revert).
+#
+# The rule rewrites the exact name `keycloak.localhost` to the in-cluster
+# Traefik Service, which already routes that Host to Keycloak via the
+# `keycloak-localhost` HTTPRoute. `answer auto` rewrites the response's owner
+# name back to `keycloak.localhost` so the caller's resolver (Go, in the
+# OpenBao pod) accepts the A record instead of discarding it as a name
+# mismatch. `exact` keeps the blast radius to this one name — no other
+# `*.localhost` is touched.
+#
+# ── Scope ──────────────────────────────────────────────────────────────────
+# Homelab only. This manifest is referenced solely from
+# overlays/homelab/kustomization.yaml. GKE uses real public DNS + TLS for
+# `keycloak.cmdbee.org`, so the rewrite would be wrong there.
+#
+# ── Verify ─────────────────────────────────────────────────────────────────
+#   kubectl -n openbao exec openbao-0 -- \
+#     nslookup keycloak.localhost
+#   # → resolves to the Traefik ClusterIP
+# CoreDNS picks up ConfigMap changes via its `reload` plugin, but imported
+# drop-ins are not always re-hashed; force it on first apply with:
+#   kubectl -n kube-system rollout restart deploy/coredns
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+  annotations:
+    # Wave 4: before cluster-identity (wave 5) and everything that follows, so
+    # in-cluster name resolution is in place early. It is just a ConfigMap, but
+    # ordering it ahead of consumers keeps first-sync logs clean.
+    argocd.argoproj.io/sync-wave: "4"
+data:
+  keycloak.override: |
+    rewrite stop {
+      name exact keycloak.localhost traefik.kube-system.svc.cluster.local
+      answer auto
+    }

--- a/platform/fundamentals/overlays/homelab/kustomization.yaml
+++ b/platform/fundamentals/overlays/homelab/kustomization.yaml
@@ -17,7 +17,10 @@ resources:
 
   # Homelab Specific Manifests
   - ../../manifests/cluster-identity-homelab.yaml
-  
+  # CoreDNS rewrite so the in-cluster OpenBao pod can resolve keycloak.localhost
+  # for the server-side OIDC token exchange (homelab-only; GKE uses real DNS).
+  - ../../manifests/coredns-custom-homelab.yaml
+
   # Exclusions
   # We do NOT include cert-manager.yaml here.
 


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Add a **homelab-only** CoreDNS rewrite so in-cluster *pods* resolve `keycloak.localhost` to the Traefik Service. Keycloak runs in dynamic-hostname mode (issuer follows the request host), and server-side OIDC consumers — first up, OpenBao's authorization-code → token exchange backing leidangr's `bao login -method=oidc` — must reach Keycloak at the same `keycloak.localhost` issuer the browser uses. Browsers get `*.localhost` for free (RFC 6761); pods don't.
- New `coredns-custom` ConfigMap (`keycloak.override`, `rewrite … answer auto`) in `platform/fundamentals/manifests/`, referenced **only** from the homelab overlay (GKE uses real `keycloak.cmdbee.org` DNS).
- Documented in `docs/keycloak-localhost-coredns.md` (split-horizon rationale + the easy-to-miss `answer auto` detail) with a README pointer.

## Test plan

- [x] `kubectl kustomize --load-restrictor LoadRestrictionsNone platform/fundamentals/overlays/homelab` includes the `coredns-custom` CM; GKE overlay does not.
- [x] On homelab, `openbao-0` resolves `keycloak.localhost` to the Traefik ClusterIP and fetches the `siliconsaga` OIDC discovery doc through Traefik.
- [x] Full `bao login -method=oidc` succeeds end-to-end (server-side token exchange via the rewrite) → token issued.

## Related

- Supports the leidangr OpenBao OIDC login work (see SiliconSaga/leidangr `docs/oidc-as-built`).
