### PR TITLE
feat(nordri): per-target nidavellir hydration + kubicvalheim mirror

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -412,20 +412,38 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
     #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
     #      self-signed Gateway cert so its websecure listener programs.
-    #   2. Stamp a per-machine tailscale operator hostname so multiple homelab
-    #      clusters never collide on a single tailnet device name. Each Mac runs
-    #      exactly one cluster, so the host machine name is a stable unique id.
-    NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
-    NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
-    [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-        sed -i '' "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    #   2. Stamp the tailscale operator hostname. GKE is a single shared cluster,
+    #      so it gets a stable `tailscale-operator-gke`; each homelab cluster is
+    #      per-machine (one cluster per Mac) so it gets `tailscale-operator-<machine>`
+    #      to avoid tailnet device-name collisions. The workstation name is a valid
+    #      identity only for homelab — deriving it on GKE would churn the device
+    #      name between hydrations run from different machines.
+    # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
+    # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
+    _nid_vegvisir_app="$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+    _nid_tailscale_app="$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    for _nid_f in "$_nid_vegvisir_app" "$_nid_tailscale_app"; do
+        if [[ ! -f "$_nid_f" ]]; then
+            echo "❌ Expected nidavellir manifest missing: ${_nid_f#"$NIDAVELLIR_HYDRATE"/} — has apps/ been renamed? Cannot apply the per-target patch." >&2
+            exit 1
+        fi
+    done
+    if [[ "$TARGET" == "gke" ]]; then
+        TS_HOSTNAME="tailscale-operator-gke"
     else
-        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-        sed -i "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+        NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+        NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
+        [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
+        TS_HOSTNAME="tailscale-operator-$NID_MACHINE"
     fi
-    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: tailscale-operator-$NID_MACHINE)."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
+        sed -i '' "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
+    else
+        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
+        sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
+    fi
+    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
 
     cd "$NIDAVELLIR_HYDRATE"
     git init

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -443,6 +443,17 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
         sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
         sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
     fi
+    # Verify the substitutions took effect — sed exits 0 even when nothing
+    # matched, so a renamed placeholder upstream would silently push the wrong
+    # overlay path / an unstamped hostname (the exact failure modes this prevents).
+    if ! grep -q "path: vegvisir/manifests/overlays/$TARGET" "$_nid_vegvisir_app"; then
+        echo "❌ vegvisir overlay path not patched — the 'overlays/homelab' placeholder may have changed in nidavellir." >&2
+        exit 1
+    fi
+    if ! grep -q "$TS_HOSTNAME" "$_nid_tailscale_app"; then
+        echo "❌ tailscale operator hostname not stamped — the 'tailscale-operator-MACHINE' placeholder may have changed in nidavellir." >&2
+        exit 1
+    fi
     echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
 
     cd "$NIDAVELLIR_HYDRATE"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -407,6 +407,26 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
     rm -rf "$NIDAVELLIR_HYDRATE/.git"  # Don't push source .git dir
 
+    # Per-target patching of the hydrated nidavellir tree (mirrors the nordri
+    # app-of-apps overlay sed above). Two cluster-specific rewrites:
+    #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
+    #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
+    #      self-signed Gateway cert so its websecure listener programs.
+    #   2. Stamp a per-machine tailscale operator hostname so multiple homelab
+    #      clusters never collide on a single tailnet device name. Each Mac runs
+    #      exactly one cluster, so the host machine name is a stable unique id.
+    NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+    NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
+    [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+        sed -i '' "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    else
+        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+        sed -i "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    fi
+    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: tailscale-operator-$NID_MACHINE)."
+
     cd "$NIDAVELLIR_HYDRATE"
     git init
     git config user.email "bootstrap@nordri.local"

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -78,7 +78,7 @@ HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 # git history and tags, so in-cluster ArgoCD apps can pin exact upstream
 # tags (e.g. keycloak-operator pins targetRevision "26.6.3"). Space-
 # separated list of component dir names under the workspace components/.
-VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
+VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources kubicvalheim}"
 
 # Resolve Gitea admin credentials.
 #
@@ -293,6 +293,26 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     TEMP_DIRS+=("$NIDAVELLIR_HYDRATE")
     cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
     rm -rf "$NIDAVELLIR_HYDRATE/.git"
+
+    # Per-target patching of the hydrated nidavellir tree (mirrors the nordri
+    # app-of-apps overlay sed above). Two cluster-specific rewrites:
+    #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
+    #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
+    #      self-signed Gateway cert so its websecure listener programs.
+    #   2. Stamp a per-machine tailscale operator hostname so multiple homelab
+    #      clusters never collide on a single tailnet device name. Each Mac runs
+    #      exactly one cluster, so the host machine name is a stable unique id.
+    NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+    NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
+    [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+        sed -i '' "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    else
+        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+        sed -i "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    fi
+    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: tailscale-operator-$NID_MACHINE)."
 
     cd "$NIDAVELLIR_HYDRATE"
     git init

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -78,7 +78,7 @@ HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 # git history and tags, so in-cluster ArgoCD apps can pin exact upstream
 # tags (e.g. keycloak-operator pins targetRevision "26.6.3"). Space-
 # separated list of component dir names under the workspace components/.
-VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources kubicvalheim}"
+VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
 
 # Resolve Gitea admin credentials.
 #

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -299,20 +299,38 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
     #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
     #      self-signed Gateway cert so its websecure listener programs.
-    #   2. Stamp a per-machine tailscale operator hostname so multiple homelab
-    #      clusters never collide on a single tailnet device name. Each Mac runs
-    #      exactly one cluster, so the host machine name is a stable unique id.
-    NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
-    NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
-    [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-        sed -i '' "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    #   2. Stamp the tailscale operator hostname. GKE is a single shared cluster,
+    #      so it gets a stable `tailscale-operator-gke`; each homelab cluster is
+    #      per-machine (one cluster per Mac) so it gets `tailscale-operator-<machine>`
+    #      to avoid tailnet device-name collisions. The workstation name is a valid
+    #      identity only for homelab — deriving it on GKE would churn the device
+    #      name between hydrations run from different machines.
+    # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
+    # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
+    _nid_vegvisir_app="$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
+    _nid_tailscale_app="$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+    for _nid_f in "$_nid_vegvisir_app" "$_nid_tailscale_app"; do
+        if [[ ! -f "$_nid_f" ]]; then
+            echo "❌ Expected nidavellir manifest missing: ${_nid_f#"$NIDAVELLIR_HYDRATE"/} — has apps/ been renamed? Cannot apply the per-target patch." >&2
+            exit 1
+        fi
+    done
+    if [[ "$TARGET" == "gke" ]]; then
+        TS_HOSTNAME="tailscale-operator-gke"
     else
-        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-        sed -i "s|tailscale-operator-MACHINE|tailscale-operator-$NID_MACHINE|g" "$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
+        NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+        NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
+        [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
+        TS_HOSTNAME="tailscale-operator-$NID_MACHINE"
     fi
-    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: tailscale-operator-$NID_MACHINE)."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
+        sed -i '' "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
+    else
+        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
+        sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
+    fi
+    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
 
     cd "$NIDAVELLIR_HYDRATE"
     git init

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -330,6 +330,17 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
         sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
         sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
     fi
+    # Verify the substitutions took effect — sed exits 0 even when nothing
+    # matched, so a renamed placeholder upstream would silently push the wrong
+    # overlay path / an unstamped hostname (the exact failure modes this prevents).
+    if ! grep -q "path: vegvisir/manifests/overlays/$TARGET" "$_nid_vegvisir_app"; then
+        echo "❌ vegvisir overlay path not patched — the 'overlays/homelab' placeholder may have changed in nidavellir." >&2
+        exit 1
+    fi
+    if ! grep -q "$TS_HOSTNAME" "$_nid_tailscale_app"; then
+        echo "❌ tailscale operator hostname not stamped — the 'tailscale-operator-MACHINE' placeholder may have changed in nidavellir." >&2
+        exit 1
+    fi
     echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
 
     cd "$NIDAVELLIR_HYDRATE"


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- Adds a per-target patch step for the hydrated nidavellir tree to both `bootstrap.sh` and `update-embedded-git.sh` (nidavellir previously hydrated wholesale, unlike nordri's app-of-apps overlay sed). Two cluster-specific rewrites:
  - Point the vegvisir app at `overlays/$TARGET` so the LetsEncrypt issuers + `*.cmdbee.org` wildcard cert only land on GKE; homelab keeps the self-signed Gateway cert (deploy-side half of the paired nidavellir env-awareness CR).
  - Stamp a per-machine tailscale operator hostname (`tailscale-operator-<machine>`, derived at hydrate time) so multiple homelab clusters don't collide on one tailnet device name.
- **Interim:** appends `kubicvalheim` to `VENDOR_MIRRORS` so the in-cluster Gitea mirrors it for ArgoCD (Valheim flavor-3). This hardcodes a per-game mirror in platform infra, which we intend to make realm-config-driven; flagged for redesign.

## Test plan

- [x] Live on homelab k3d: `update-embedded-git.sh homelab` hydrated the patched nidavellir; ArgoCD reconciled vegvisir env-aware (Healthy) and the tailscale operator rolled to `tailscale-operator-<machine>`.
- [ ] GKE path (`update-embedded-git.sh gke`) rewrites the vegvisir app to `overlays/gke` — to confirm on next GKE hydration.

## Related

- Parked arcs: homelab-cluster-env-awareness, bootstrap-vendor-mirror-hydration. Paired with the nidavellir env-awareness CR. The VENDOR_MIRRORS game entry is a placeholder pending the realm-config enablement design.
