### PR TITLE
Realm-owned config: hydration-dedup refactor + owning-realm bootstrap

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts and the sourced lib/ must stay LF: bash (including Git Bash /
+# MSYS2 on Windows) fails to source or run scripts that carry CRLF line endings.
+# Without this, core.autocrlf=true converts *.sh to CRLF on checkout and breaks
+# bootstrap.sh / update-embedded-git.sh and everything they source from lib/.
+*.sh text eol=lf

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,6 +54,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Shared hydration libraries (extracted from the duplicated inline blocks).
 . "$SCRIPT_DIR/lib/gitea.sh"
+. "$SCRIPT_DIR/lib/hydrate.sh"
 . "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 # Capture explicit GITEA_PASS env input here without applying a default —
@@ -83,6 +84,13 @@ NIDAVELLIR_DIR="${NIDAVELLIR_DIR:-$(dirname "$SCRIPT_DIR")/nidavellir}"
 MIMIR_DIR="${MIMIR_DIR:-$(dirname "$SCRIPT_DIR")/mimir}"
 HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 INTERNAL_GITEA_URL="http://gitea-http.gitea.svc.cluster.local:3000"
+# Fresh-cluster bootstrap: repos are created with auto_init so ArgoCD can
+# resolve HEAD. The working-tree hydration helper reads this.
+HYDRATE_AUTO_INIT=true
+# Vendored upstream mirrors to push (real history + tags) so in-cluster apps can
+# pin exact upstream refs. Space-separated component dir names; same default as
+# update-embedded-git.sh.
+VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
 
 if [[ -z "$TARGET" ]]; then
     echo "Usage: ./bootstrap.sh [gke|homelab]"
@@ -351,101 +359,20 @@ echo "✅ Nordri configuration hydrated to Seed Gitea."
 # Also push Nidavellir to Gitea so ArgoCD can manage Vegvísir (Gateway + TLS).
 # ArgoCD pulls from internal Gitea during bootstrap; can be swapped to GitHub later.
 # See nidavellir/vegvisir/README.md for the transition procedure.
-if [[ -d "$NIDAVELLIR_DIR" ]]; then
-    echo "💧 [Layer 2] Hydrating Nidavellir to Seed Gitea..."
-
-    gitea_ensure_repo "$NIDAVELLIR_GITEA_REPO" true
-
-    NIDAVELLIR_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$NIDAVELLIR_HYDRATE")
-    cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
-    rm -rf "$NIDAVELLIR_HYDRATE/.git"  # Don't push source .git dir
-
-    if ! TS_HOSTNAME="$(patch_nidavellir_tree "$NIDAVELLIR_HYDRATE" "$TARGET")"; then
-        exit 1
-    fi
-    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
-
-    cd "$NIDAVELLIR_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Bootstrap"
-    git checkout -b main
-    git add .
-    git commit -m "Hydration for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$NIDAVELLIR_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$NIDAVELLIR_HYDRATE"
-
-    echo "✅ Nidavellir hydrated to Seed Gitea."
-else
-    echo "⚠️  Nidavellir directory not found at: $NIDAVELLIR_DIR"
-    echo "   Set NIDAVELLIR_DIR env var or clone nidavellir as a sibling of this repo."
-    echo "   Vegvísir (Gateway + TLS) will not be deployed until Nidavellir is available."
-fi
+hydrate_working_tree_repo "$NIDAVELLIR_DIR" "$NIDAVELLIR_GITEA_REPO" "Hydration for $TARGET" patch_nidavellir_tree
 
 # Also push Mimir to Gitea so ArgoCD can deploy data service operators + XRDs.
 # Mimir is referenced by nidavellir/apps/mimir-app.yaml (sync-wave 6).
-if [[ -d "$MIMIR_DIR" ]]; then
-    echo "💧 [Layer 2] Hydrating Mimir to Seed Gitea..."
-
-    gitea_ensure_repo "$MIMIR_GITEA_REPO" true
-
-    MIMIR_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$MIMIR_HYDRATE")
-    cp -r "$MIMIR_DIR/." "$MIMIR_HYDRATE/"
-    rm -rf "$MIMIR_HYDRATE/.git"  # Don't push source .git dir
-
-    cd "$MIMIR_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Bootstrap"
-    git checkout -b main
-    git add .
-    git commit -m "Hydration for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$MIMIR_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$MIMIR_HYDRATE"
-
-    echo "✅ Mimir hydrated to Seed Gitea."
-else
-    echo "⚠️  Mimir directory not found at: $MIMIR_DIR"
-    echo "   Set MIMIR_DIR env var or clone mimir as a sibling of this repo."
-    echo "   Data services will not be deployed until Mimir is available."
-fi
+hydrate_working_tree_repo "$MIMIR_DIR" "$MIMIR_GITEA_REPO" "Hydration for $TARGET"
 
 # Also push Heimdall to Gitea so ArgoCD can deploy the observability stack.
 # Heimdall is referenced by nidavellir/apps/heimdall-app.yaml (sync-wave 10).
-if [[ -d "$HEIMDALL_DIR" ]]; then
-    echo "💧 [Layer 2] Hydrating Heimdall to Seed Gitea..."
+hydrate_working_tree_repo "$HEIMDALL_DIR" "$HEIMDALL_GITEA_REPO" "Hydration for $TARGET"
 
-    gitea_ensure_repo "$HEIMDALL_GITEA_REPO" true
-
-    HEIMDALL_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$HEIMDALL_HYDRATE")
-    cp -r "$HEIMDALL_DIR/." "$HEIMDALL_HYDRATE/"
-    rm -rf "$HEIMDALL_HYDRATE/.git"  # Don't push source .git dir
-
-    cd "$HEIMDALL_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Bootstrap"
-    git checkout -b main
-    git add .
-    git commit -m "Hydration for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$HEIMDALL_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$HEIMDALL_HYDRATE"
-
-    echo "✅ Heimdall hydrated to Seed Gitea."
-else
-    echo "⚠️  Heimdall directory not found at: $HEIMDALL_DIR"
-    echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
-    echo "   Observability stack will not be deployed until Heimdall is available."
-fi
+# Vendor mirrors: push real history + tags so in-cluster apps can pin exact
+# upstream refs (e.g. keycloak-operator pins tag 26.6.3). Also run day-2 by
+# update-embedded-git.sh; running it here makes a fresh bootstrap reproducible.
+hydrate_vendor_mirrors "$VENDOR_MIRRORS"
 
 # --- Step 2.5: Install Crossplane Core (Layer 2.5) ---
 # Gateway API CRDs were installed here in earlier versions, but Traefik chart

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,7 +52,8 @@ set -e
 #               to ../<name> relative to this script.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# Shared hydration library (extracted from the duplicated inline blocks).
+# Shared hydration libraries (extracted from the duplicated inline blocks).
+. "$SCRIPT_DIR/lib/gitea.sh"
 . "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 # Capture explicit GITEA_PASS env input here without applying a default —
@@ -224,19 +225,7 @@ kubectl create secret generic "$GITEA_CREDENTIALS_SECRET" \
 # percent-encode user/pass to handle special chars (@, :, /, #) without
 # corrupting the URL. API calls go through curl -u instead and just use
 # the credentials-less base URL.
-urlencode() { jq -rn --arg s "$1" '$s|@uri'; }
-GITEA_USER_ENC="$(urlencode "$GITEA_USER")"
-GITEA_PASS_ENC="$(urlencode "$GITEA_PASS")"
-GITEA_API_URL="${GITEA_SCHEME}://${GITEA_HOST}"
-GITEA_GIT_BASE="${GITEA_SCHEME}://${GITEA_USER_ENC}:${GITEA_PASS_ENC}@${GITEA_HOST}"
-GITEA_PROBE_URL="${GITEA_API_URL}/api/v1/version"
-
-# Probe the Gitea endpoint. Returns 0 if Gitea answers /api/v1/version
-# with HTTP 200. Used to confirm we're talking to actual Gitea, not just
-# any service that happens to be on this host:port.
-probe_gitea() {
-    curl -fsS --max-time 5 "$GITEA_PROBE_URL" >/dev/null 2>&1
-}
+gitea_build_urls
 
 # We use a simple configuration for the seed instance
 helm upgrade --install gitea gitea-charts/gitea \
@@ -319,47 +308,10 @@ else
     fi
 fi
 
-# Create a Gitea repo via API with retry. Gitea's ephemeral mode can fail on rapid
-# sequential repo creates (initRepository race). We check the response body for errors.
-create_gitea_repo() {
-    local repo_name=$1
-    local max_retries=5
-    for i in $(seq 1 $max_retries); do
-        # `-u user:pass` keeps credentials out of the URL so special chars
-        # in GITEA_PASS (@, :, /, #) can't corrupt URL parsing.
-        # `|| true` after the command substitution prevents `set -e` from
-        # killing the retry loop on transport-level curl failures (DNS,
-        # TCP refusal, TLS handshake) — those are exactly the cases the
-        # retry exists to cover.
-        # `auto_init: true` creates an initial commit on `main` and sets the
-        # repo's HEAD symbolic ref to it. Without auto-init, a fresh repo has
-        # no HEAD ref — our later `git push --force` creates `refs/heads/main`
-        # but HEAD remains unresolved, and ArgoCD apps using `targetRevision:
-        # HEAD` fail with `unable to resolve 'HEAD' to a commit SHA`. The
-        # force-push later in the script overwrites the auto-init commit.
-        RESPONSE=$(curl -s -u "$GITEA_USER:$GITEA_PASS" \
-          -X POST "$GITEA_API_URL/api/v1/user/repos" \
-          -H "Content-Type: application/json" \
-          -d "{\"name\": \"$repo_name\", \"private\": false, \"auto_init\": true, \"default_branch\": \"main\"}" || true)
-
-        # Check if response contains a valid repo (has "clone_url") or already-exists error
-        if echo "$RESPONSE" | grep -q '"clone_url"'; then
-            echo "   Created repo: $repo_name"
-            return 0
-        elif echo "$RESPONSE" | grep -q 'already exists'; then
-            echo "   Repo $repo_name already exists."
-            return 0
-        else
-            echo "   Repo creation attempt $i/$max_retries failed for $repo_name: $(echo "$RESPONSE" | head -c 120)"
-            sleep 5
-        fi
-    done
-    echo "❌ Failed to create repo $repo_name after $max_retries attempts."
-    return 1
-}
+# gitea_ensure_repo (create-if-missing; auto_init for fresh repos) lives in lib/gitea.sh.
 
 # Create all repos upfront (sequential with retry to avoid Gitea init races)
-create_gitea_repo "$GITEA_REPO_NAME"
+gitea_ensure_repo "$GITEA_REPO_NAME" true
 
 # Prepare the content
 # Copy platform shared files
@@ -402,7 +354,7 @@ echo "✅ Nordri configuration hydrated to Seed Gitea."
 if [[ -d "$NIDAVELLIR_DIR" ]]; then
     echo "💧 [Layer 2] Hydrating Nidavellir to Seed Gitea..."
 
-    create_gitea_repo "$NIDAVELLIR_GITEA_REPO"
+    gitea_ensure_repo "$NIDAVELLIR_GITEA_REPO" true
 
     NIDAVELLIR_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$NIDAVELLIR_HYDRATE")
@@ -438,7 +390,7 @@ fi
 if [[ -d "$MIMIR_DIR" ]]; then
     echo "💧 [Layer 2] Hydrating Mimir to Seed Gitea..."
 
-    create_gitea_repo "$MIMIR_GITEA_REPO"
+    gitea_ensure_repo "$MIMIR_GITEA_REPO" true
 
     MIMIR_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$MIMIR_HYDRATE")
@@ -469,7 +421,7 @@ fi
 if [[ -d "$HEIMDALL_DIR" ]]; then
     echo "💧 [Layer 2] Hydrating Heimdall to Seed Gitea..."
 
-    create_gitea_repo "$HEIMDALL_GITEA_REPO"
+    gitea_ensure_repo "$HEIMDALL_GITEA_REPO" true
 
     HEIMDALL_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$HEIMDALL_HYDRATE")

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -107,6 +107,12 @@ fi
 # Omit it for a generic demo-only stack. REALM_DIR overrides the default
 # <workspace>/realms/<realm> resolution (nordri lives at <workspace>/components/nordri).
 REALM="${2:-}"
+if [[ -n "$REALM" ]]; then
+    if [[ ! "$REALM" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] || [[ ${#REALM} -gt 63 ]]; then
+        echo "❌ Realm '$REALM' must be a DNS-1123 label (lowercase alphanumeric and '-', max 63 chars) — it names a Gitea repo and a Kubernetes Application." >&2
+        exit 1
+    fi
+fi
 REALM_DIR="${REALM_DIR:-}"
 if [[ -n "$REALM" && -z "$REALM_DIR" ]]; then
     REALM_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")/realms/$REALM"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,12 +93,27 @@ HYDRATE_AUTO_INIT=true
 VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
 
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: ./bootstrap.sh [gke|homelab]"
+    echo "Usage: ./bootstrap.sh [gke|homelab] [realm]"
     exit 1
 fi
 
 if [[ "$TARGET" != "gke" && "$TARGET" != "homelab" ]]; then
     echo "Error: Target must be 'gke' or 'homelab'"
+    exit 1
+fi
+
+# Optional owning realm (arg 2): a realm whose cluster/ subtree carries
+# realm-owned in-cluster config (e.g. the siliconsaga keycloak realm-import).
+# Omit it for a generic demo-only stack. REALM_DIR overrides the default
+# <workspace>/realms/<realm> resolution (nordri lives at <workspace>/components/nordri).
+REALM="${2:-}"
+REALM_DIR="${REALM_DIR:-}"
+if [[ -n "$REALM" && -z "$REALM_DIR" ]]; then
+    REALM_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")/realms/$REALM"
+fi
+if [[ -n "$REALM" && ! -d "$REALM_DIR/cluster" ]]; then
+    echo "❌ Owning realm '$REALM' has no cluster/ config at: $REALM_DIR/cluster" >&2
+    echo "   Pass a realm whose repo carries cluster/, set REALM_DIR, or omit the arg for demo-only." >&2
     exit 1
 fi
 
@@ -373,6 +388,13 @@ hydrate_working_tree_repo "$HEIMDALL_DIR" "$HEIMDALL_GITEA_REPO" "Hydration for 
 # upstream refs (e.g. keycloak-operator pins tag 26.6.3). Also run day-2 by
 # update-embedded-git.sh; running it here makes a fresh bootstrap reproducible.
 hydrate_vendor_mirrors "$VENDOR_MIRRORS"
+
+# Owning realm (optional): hydrate its cluster/ subtree so ArgoCD can sync
+# realm-owned config. The realm root-app that points ArgoCD at it is registered
+# after ArgoCD is installed (see the realm root-app step below).
+if [[ -n "$REALM_DIR" ]]; then
+    hydrate_working_tree_repo "$REALM_DIR/cluster" "$REALM" "Realm config for $TARGET"
+fi
 
 # --- Step 2.5: Install Crossplane Core (Layer 2.5) ---
 # Gateway API CRDs were installed here in earlier versions, but Traefik chart

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -392,7 +392,7 @@ hydrate_vendor_mirrors "$VENDOR_MIRRORS"
 # Owning realm (optional): hydrate its cluster/ subtree so ArgoCD can sync
 # realm-owned config. The realm root-app that points ArgoCD at it is registered
 # after ArgoCD is installed (see the realm root-app step below).
-if [[ -n "$REALM_DIR" ]]; then
+if [[ -n "$REALM" ]]; then
     hydrate_working_tree_repo "$REALM_DIR/cluster" "$REALM" "Realm config for $TARGET"
 fi
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,6 +52,8 @@ set -e
 #               to ../<name> relative to this script.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Shared hydration library (extracted from the duplicated inline blocks).
+. "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 # Capture explicit GITEA_PASS env input here without applying a default —
 # the resolver populates the value below. Username is fixed to
@@ -407,51 +409,7 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
     rm -rf "$NIDAVELLIR_HYDRATE/.git"  # Don't push source .git dir
 
-    # Per-target patching of the hydrated nidavellir tree (mirrors the nordri
-    # app-of-apps overlay sed above). Two cluster-specific rewrites:
-    #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
-    #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
-    #      self-signed Gateway cert so its websecure listener programs.
-    #   2. Stamp the tailscale operator hostname. GKE is a single shared cluster,
-    #      so it gets a stable `tailscale-operator-gke`; each homelab cluster is
-    #      per-machine (one cluster per Mac) so it gets `tailscale-operator-<machine>`
-    #      to avoid tailnet device-name collisions. The workstation name is a valid
-    #      identity only for homelab — deriving it on GKE would churn the device
-    #      name between hydrations run from different machines.
-    # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
-    # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
-    _nid_vegvisir_app="$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-    _nid_tailscale_app="$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
-    for _nid_f in "$_nid_vegvisir_app" "$_nid_tailscale_app"; do
-        if [[ ! -f "$_nid_f" ]]; then
-            echo "❌ Expected nidavellir manifest missing: ${_nid_f#"$NIDAVELLIR_HYDRATE"/} — has apps/ been renamed? Cannot apply the per-target patch." >&2
-            exit 1
-        fi
-    done
-    if [[ "$TARGET" == "gke" ]]; then
-        TS_HOSTNAME="tailscale-operator-gke"
-    else
-        NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
-        NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
-        [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
-        TS_HOSTNAME="tailscale-operator-$NID_MACHINE"
-    fi
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
-        sed -i '' "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
-    else
-        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
-        sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
-    fi
-    # Verify the substitutions took effect — sed exits 0 even when nothing
-    # matched, so a renamed placeholder upstream would silently push the wrong
-    # overlay path / an unstamped hostname (the exact failure modes this prevents).
-    if ! grep -q "path: vegvisir/manifests/overlays/$TARGET" "$_nid_vegvisir_app"; then
-        echo "❌ vegvisir overlay path not patched — the 'overlays/homelab' placeholder may have changed in nidavellir." >&2
-        exit 1
-    fi
-    if ! grep -q "$TS_HOSTNAME" "$_nid_tailscale_app"; then
-        echo "❌ tailscale operator hostname not stamped — the 'tailscale-operator-MACHINE' placeholder may have changed in nidavellir." >&2
+    if ! TS_HOSTNAME="$(patch_nidavellir_tree "$NIDAVELLIR_HYDRATE" "$TARGET")"; then
         exit 1
     fi
     echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -534,6 +534,16 @@ kubectl apply -f "$SCRIPT_DIR/platform/root-app.yaml" -n argo
 
 echo "✅ Root Application applied. ArgoCD is now syncing from the internal Seed Gitea."
 
+# Owning realm (optional): register a generic root-app pointing ArgoCD at the
+# hydrated realm repo. Templated from the realm arg so nordri commits no
+# realm-specific value. The realm's resources retry until the platform CRDs
+# (Keycloak operator, ESO) they depend on exist.
+if [[ -n "$REALM" ]]; then
+    echo "🔗 [Layer 4] Registering realm root-app for '$REALM'..."
+    sed "s|__REALM_REPO__|$REALM|g" "$SCRIPT_DIR/platform/argocd/realm-root-app.template.yaml" \
+        | kubectl apply -n argo -f -
+fi
+
 # --- GKE: Pre-create Velero namespace + dummy credentials ---
 # Velero's Helm chart requires the velero-credentials secret to exist before the pod
 # starts. ArgoCD begins syncing Velero immediately after the root app is applied, so

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -16,7 +16,9 @@ Provision the raw cluster before running any scripts.
 - **Homelab**: k3s/Rancher Desktop, pre-existing
 
 ### Layer 2 — The Seed (Gitea + Nidavellir hydration)
-`./bootstrap.sh [gke|homelab]`
+`./bootstrap.sh [gke|homelab] [realm]`
+
+The optional second arg names an **owning realm** whose `cluster/` subtree carries realm-owned in-cluster config (e.g. the SiliconSaga keycloak realm-import). When given, bootstrap hydrates `realms/<realm>/cluster/` into a seed-Gitea repo named `<realm>` and registers a generic ArgoCD realm root-app pointed at it (after ArgoCD is up — see Layer 3). Omit it for a generic demo-only stack. `REALM_DIR` overrides the default `<workspace>/realms/<realm>` resolution.
 
 - Installs **Gitea** (Helm, `gitea` namespace, ephemeral — no persistence)
 - **Resolves Gitea admin credentials** and persists them to the

--- a/lib/gitea.sh
+++ b/lib/gitea.sh
@@ -1,0 +1,73 @@
+# components/nordri/lib/gitea.sh
+# Shared Gitea plumbing for bootstrap.sh and update-embedded-git.sh.
+# Expects GITEA_SCHEME / GITEA_HOST / GITEA_USER / GITEA_PASS to be set by the
+# caller (each script resolves credentials its own way) before gitea_build_urls.
+
+# Percent-encode a string so credentials with special chars (@, :, /, #) can be
+# embedded in a git URL without corrupting URL parsing.
+urlencode() { jq -rn --arg s "$1" '$s|@uri'; }
+
+# Build the Gitea URL bases from the resolved GITEA_* vars.
+# Sets: GITEA_API_URL, GITEA_GIT_BASE, GITEA_PROBE_URL.
+gitea_build_urls() {
+    local user_enc pass_enc
+    user_enc="$(urlencode "$GITEA_USER")"
+    pass_enc="$(urlencode "$GITEA_PASS")"
+    GITEA_API_URL="${GITEA_SCHEME}://${GITEA_HOST}"
+    GITEA_GIT_BASE="${GITEA_SCHEME}://${user_enc}:${pass_enc}@${GITEA_HOST}"
+    GITEA_PROBE_URL="${GITEA_API_URL}/api/v1/version"
+}
+
+# Probe the Gitea endpoint. Returns 0 if Gitea answers /api/v1/version, non-zero
+# otherwise — confirms we're talking to actual Gitea, not just any listener on
+# this host:port, before sending credentials.
+probe_gitea() {
+    curl -fsS --max-time 5 "$GITEA_PROBE_URL" >/dev/null 2>&1
+}
+
+# Ensure a Gitea repo exists (create if missing). Treats 201 (Created) and 409
+# (already exists) as success; retries transport errors up to 5x with a short
+# backoff, then prints the response body and fails.
+#
+# Second arg auto_init=true is for FRESH repos (bootstrap): it creates an initial
+# commit on `main` and sets HEAD, which ArgoCD apps using `targetRevision: HEAD`
+# require — without it a fresh repo has no resolvable HEAD. The later force-push
+# overwrites that auto-init commit. Day-2 callers (update-embedded-git.sh) omit
+# it: the repo already exists with a HEAD, so 409 is the normal outcome.
+gitea_ensure_repo() {
+    local repo_name=$1 auto_init=${2:-false}
+    local max_retries=5
+    local i status response_file body
+    body="{\"name\": \"$repo_name\", \"private\": false"
+    if [[ "$auto_init" == "true" ]]; then
+        body="$body, \"auto_init\": true, \"default_branch\": \"main\""
+    fi
+    body="$body}"
+    for i in $(seq 1 $max_retries); do
+        response_file=$(mktemp)
+        # `-u user:pass` keeps credentials out of the URL so special chars in
+        # $GITEA_PASS can't corrupt URL parsing.
+        status=$(curl -sS -o "$response_file" -w "%{http_code}" \
+            -u "$GITEA_USER:$GITEA_PASS" \
+            -X POST "$GITEA_API_URL/api/v1/user/repos" \
+            -H "Content-Type: application/json" \
+            -d "$body") || true
+        case "$status" in
+            201|409)
+                rm -f "$response_file"
+                return 0
+                ;;
+        esac
+        if [[ $i -lt $max_retries ]]; then
+            echo "   Repo creation attempt $i/$max_retries for '$repo_name' returned HTTP $status; retrying in 5s..." >&2
+            rm -f "$response_file"
+            sleep 5
+            continue
+        fi
+        echo "❌ Failed to create or confirm Gitea repo '$repo_name' after $max_retries attempts (HTTP $status):" >&2
+        cat "$response_file" >&2
+        echo >&2
+        rm -f "$response_file"
+        return 1
+    done
+}

--- a/lib/gitea.sh
+++ b/lib/gitea.sh
@@ -38,11 +38,10 @@ gitea_ensure_repo() {
     local repo_name=$1 auto_init=${2:-false}
     local max_retries=5
     local i status response_file body
-    body="{\"name\": \"$repo_name\", \"private\": false"
-    if [[ "$auto_init" == "true" ]]; then
-        body="$body, \"auto_init\": true, \"default_branch\": \"main\""
-    fi
-    body="$body}"
+    # Build the body with jq so a repo name containing quotes/backslashes can't
+    # corrupt the JSON. auto_init ("true"/"false") is injected as a JSON boolean.
+    body=$(jq -n --arg name "$repo_name" --argjson auto_init "$auto_init" \
+        '{name: $name, private: false} + (if $auto_init then {auto_init: true, default_branch: "main"} else {} end)')
     for i in $(seq 1 $max_retries); do
         response_file=$(mktemp)
         # `-u user:pass` keeps credentials out of the URL so special chars in

--- a/lib/hydrate.sh
+++ b/lib/hydrate.sh
@@ -1,0 +1,115 @@
+# components/nordri/lib/hydrate.sh
+# Shared seed-Gitea hydration helpers for bootstrap.sh and update-embedded-git.sh.
+# Depends on lib/gitea.sh (gitea_ensure_repo, $GITEA_GIT_BASE, $GITEA_USER) and,
+# for the working-tree helper, the caller's $TARGET and TEMP_DIRS array.
+#
+# Per-script knobs (read here, set by the caller before use):
+#   HYDRATE_AUTO_INIT  "true" for fresh-cluster bootstrap (repos need an initial
+#                      commit + resolvable HEAD); unset/false for day-2 updates.
+#   HYDRATE_COMMITTER  git author name for the ephemeral hydration commit
+#                      (default "Nordri Bootstrap").
+
+# Copy a source tree into a fresh dir, dropping its .git so we push a clean
+# orphan snapshot rather than the source history.
+hydrate_prepare_tree() {
+    local src="$1" dst="$2"
+    cp -r "$src/." "$dst/"
+    rm -rf "$dst/.git"
+}
+
+# Push a prepared tree to the seed Gitea as a forced fresh main. Runs in a
+# subshell so the caller's cwd is untouched even on failure.
+hydrate_push_tree() {
+    local dir="$1" gitea_repo="$2" commit_msg="$3"
+    (
+        cd "$dir" || exit 1
+        git init
+        git config user.email "bootstrap@nordri.local"
+        git config user.name "${HYDRATE_COMMITTER:-Nordri Bootstrap}"
+        git checkout -b main
+        git add .
+        git commit -m "$commit_msg"
+        git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$gitea_repo.git"
+        git push -u origin main --force
+    )
+}
+
+# Hydrate one working-tree component into the seed. Warn-and-skip if the source
+# dir is absent. Optional patch_fn is called as `patch_fn <tmp_tree> <target>`
+# after the copy and must return non-zero on failure (its stdout is logged).
+hydrate_working_tree_repo() {
+    local src_dir="$1" gitea_repo="$2" commit_msg="$3" patch_fn="${4:-}"
+    if [[ ! -d "$src_dir" ]]; then
+        echo "⚠️  $gitea_repo source not found at: $src_dir — skipping."
+        echo "   Set the matching *_DIR env var or clone $gitea_repo as a sibling of nordri."
+        return 0
+    fi
+    echo "💧 Hydrating '$gitea_repo' to Seed Gitea..."
+    gitea_ensure_repo "$gitea_repo" "${HYDRATE_AUTO_INIT:-false}"
+    local tmp
+    tmp="$(mktemp -d)"
+    TEMP_DIRS+=("$tmp")
+    hydrate_prepare_tree "$src_dir" "$tmp"
+    if [[ -n "$patch_fn" ]]; then
+        local patch_out
+        if ! patch_out="$("$patch_fn" "$tmp" "$TARGET")"; then
+            return 1
+        fi
+        echo "   Patched $gitea_repo for target '$TARGET' ($patch_out)."
+    fi
+    hydrate_push_tree "$tmp" "$gitea_repo" "$commit_msg"
+    rm -rf "$tmp"
+    echo "✅ '$gitea_repo' hydrated to Seed Gitea."
+}
+
+# Vendor mirrors: mirror each local clone's REAL history + tags into the seed so
+# in-cluster apps can pin an exact upstream ref (a tag, as keycloak-operator
+# pins 26.6.3, or a branch). Space-separated list of component dir names under
+# the workspace components/.
+#
+# Heads are pushed WITHOUT --prune (pruning would try to delete the seed's
+# default branch and Gitea rejects that, failing the hydration). Tags DO get
+# --prune — a retracted tag should disappear and tag pruning can't hit that
+# trap. Reads as-fetched remote-tracking refs (no network) — refresh a mirror
+# with `ws pull <vendor>`.
+hydrate_vendor_mirrors() {
+    local mirrors="$1"
+    local vendor vendor_dir vendor_branch vendor_remote vendor_seed vref vbranch vr_count
+    for vendor in $mirrors; do
+        vendor_dir="$(dirname "$SCRIPT_DIR")/$vendor"
+        # Plumbing check, not `-d .git`: a worktree/submodule has `.git` as a FILE.
+        if git -C "$vendor_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+            echo "💧 Updating vendor mirror '$vendor' in Seed Gitea..."
+            gitea_ensure_repo "$vendor"
+            # Resolve the source remote robustly (ws clone names it after the org,
+            # not "origin"): prefer the tracking remote, fall back to a sole remote,
+            # warn-and-skip if ambiguous rather than guess.
+            vendor_branch="$(git -C "$vendor_dir" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+            vendor_remote=""
+            [[ -n "$vendor_branch" ]] && vendor_remote="$(git -C "$vendor_dir" config "branch.$vendor_branch.remote" 2>/dev/null || true)"
+            if [[ -z "$vendor_remote" ]]; then
+                vr_count="$(git -C "$vendor_dir" remote | grep -c .)"
+                if [[ "$vr_count" != "1" ]]; then
+                    echo "⚠️  Vendor mirror '$vendor' has $vr_count remotes and no tracked upstream — skipping (set a single remote or a tracking branch)." >&2
+                    continue
+                fi
+                vendor_remote="$(git -C "$vendor_dir" remote)"
+            fi
+            vendor_seed="$GITEA_GIT_BASE/$GITEA_USER/$vendor.git"
+            # Default branch (reliably a local head) + every non-default upstream
+            # branch (remote-tracking, minus the HEAD symref), each mapped to a seed head.
+            local -a refspecs=("+refs/heads/*:refs/heads/*")
+            while IFS= read -r vref; do
+                vbranch="${vref#refs/remotes/$vendor_remote/}"
+                [[ "$vbranch" == "HEAD" ]] && continue
+                refspecs+=("+$vref:refs/heads/$vbranch")
+            done < <(git -C "$vendor_dir" for-each-ref --format='%(refname)' "refs/remotes/$vendor_remote")
+            git -C "$vendor_dir" push --force "$vendor_seed" "${refspecs[@]}"
+            git -C "$vendor_dir" push --force --prune "$vendor_seed" 'refs/tags/*:refs/tags/*'
+            echo "✅ Vendor mirror '$vendor' updated."
+        else
+            echo "⚠️  Vendor mirror '$vendor' not cloned at: $vendor_dir"
+            echo "   Run 'ws clone $vendor' if apps on this cluster pin it."
+        fi
+    done
+}

--- a/lib/hydrate.sh
+++ b/lib/hydrate.sh
@@ -88,7 +88,7 @@ hydrate_vendor_mirrors() {
             vendor_remote=""
             [[ -n "$vendor_branch" ]] && vendor_remote="$(git -C "$vendor_dir" config "branch.$vendor_branch.remote" 2>/dev/null || true)"
             if [[ -z "$vendor_remote" ]]; then
-                vr_count="$(git -C "$vendor_dir" remote | grep -c .)"
+                vr_count="$(git -C "$vendor_dir" remote | grep -c . || true)"
                 if [[ "$vr_count" != "1" ]]; then
                     echo "⚠️  Vendor mirror '$vendor' has $vr_count remotes and no tracked upstream — skipping (set a single remote or a tracking branch)." >&2
                     continue

--- a/lib/patch-nidavellir.sh
+++ b/lib/patch-nidavellir.sh
@@ -1,0 +1,57 @@
+# components/nordri/lib/patch-nidavellir.sh
+# Per-target patching of a hydrated nidavellir tree. Sourced by bootstrap.sh
+# and update-embedded-git.sh. Returns non-zero on any failure (caller decides
+# whether to exit). Echoes the resolved tailscale hostname on success.
+#
+# Two cluster-specific rewrites:
+#   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
+#      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
+#      self-signed Gateway cert so its websecure listener programs.
+#   2. Stamp the tailscale operator hostname. GKE is a single shared cluster,
+#      so it gets a stable `tailscale-operator-gke`; each homelab cluster is
+#      per-machine (one cluster per box) so it gets `tailscale-operator-<machine>`
+#      to avoid tailnet device-name collisions. The workstation name is a valid
+#      identity only for homelab — deriving it on GKE would churn the device
+#      name between hydrations run from different machines.
+patch_nidavellir_tree() {
+    local tree="$1" target="$2"
+    local vegvisir_app="$tree/apps/vegvisir-app.yaml"
+    local tailscale_app="$tree/apps/tailscale-operator-app.yaml"
+    local f ts_hostname machine
+    # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
+    # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
+    for f in "$vegvisir_app" "$tailscale_app"; do
+        if [[ ! -f "$f" ]]; then
+            echo "❌ Expected nidavellir manifest missing: ${f#"$tree"/} — has apps/ been renamed?" >&2
+            return 1
+        fi
+    done
+    if [[ "$target" == "gke" ]]; then
+        ts_hostname="tailscale-operator-gke"
+    else
+        machine="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
+        machine="$(printf '%s' "$machine" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
+        [[ -z "$machine" ]] && machine="local"
+        ts_hostname="tailscale-operator-$machine"
+    fi
+    # Portable sed -i (BSD/macOS needs '' as the backup extension, GNU/MSYS must not).
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$target|g" "$vegvisir_app"
+        sed -i '' "s|tailscale-operator-MACHINE|$ts_hostname|g" "$tailscale_app"
+    else
+        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$target|g" "$vegvisir_app"
+        sed -i "s|tailscale-operator-MACHINE|$ts_hostname|g" "$tailscale_app"
+    fi
+    # Verify the substitutions took effect — sed exits 0 even when nothing
+    # matched, so a renamed placeholder upstream would silently push the wrong
+    # overlay path / an unstamped hostname (the exact failure modes this prevents).
+    if ! grep -q "path: vegvisir/manifests/overlays/$target" "$vegvisir_app"; then
+        echo "❌ vegvisir overlay path not patched — the 'overlays/homelab' placeholder may have changed." >&2
+        return 1
+    fi
+    if ! grep -q "$ts_hostname" "$tailscale_app"; then
+        echo "❌ tailscale operator hostname not stamped — the 'tailscale-operator-MACHINE' placeholder may have changed." >&2
+        return 1
+    fi
+    printf '%s' "$ts_hostname"
+}

--- a/lib/patch-nidavellir.sh
+++ b/lib/patch-nidavellir.sh
@@ -18,6 +18,17 @@ patch_nidavellir_tree() {
     local vegvisir_app="$tree/apps/vegvisir-app.yaml"
     local tailscale_app="$tree/apps/tailscale-operator-app.yaml"
     local f ts_hostname machine
+    # Validate the caller-supplied target before any sed: an empty/unknown target
+    # would rewrite `overlays/homelab` → `overlays/<bad>` AND still pass the later
+    # verification (which greps the same substituted value), silently corrupting
+    # the manifest path.
+    case "$target" in
+        homelab|gke) ;;
+        *)
+            echo "❌ patch_nidavellir_tree: unknown target '$target' (expected homelab|gke)." >&2
+            return 1
+            ;;
+    esac
     # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
     # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
     for f in "$vegvisir_app" "$tailscale_app"; do

--- a/platform/argocd/realm-root-app.template.yaml
+++ b/platform/argocd/realm-root-app.template.yaml
@@ -1,0 +1,40 @@
+# Generic realm root-app. bootstrap.sh substitutes __REALM_REPO__ with the
+# owning realm's seed-Gitea repo name and applies it. nordri never commits a
+# realm-specific value — this file stays realm-agnostic.
+#
+# The seed repo holds the realm's cluster/ CONTENTS at its root (bootstrap
+# hydrates realms/<realm>/cluster/ into repo <realm>), so path is ".".
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: __REALM_REPO__
+  namespace: argo
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: 'http://gitea-http.gitea.svc.cluster.local:3000/nordri-admin/__REALM_REPO__.git'
+    targetRevision: HEAD
+    path: .
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argo
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    # The realm config (e.g. KeycloakRealmImport, ExternalSecret) depends on CRDs
+    # the platform installs (Keycloak operator, ESO). This is a SEPARATE
+    # Application from nidavellir's, so cross-app sync-waves don't order it —
+    # instead ArgoCD retries until those CRDs exist, and
+    # SkipDryRunOnMissingResource avoids a hard dry-run failure meanwhile.
+    syncOptions:
+      - CreateNamespace=true
+      - SkipDryRunOnMissingResource=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 30s
+        factor: 2
+        maxDuration: 5m

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# nordri test/lint runner — invoked by the ws adapter (realm adapters/nordri.yaml).
+# Cluster-free: syntax-checks the entry-point scripts + libs and runs the lib
+# unit tests. The kuttl e2e suites (kuttl-test-*.yaml) need a live cluster and
+# are run separately (see docs/kuttl-tests.md), NOT here.
+#
+# Usage: tests/run.sh [test|lint]   (default: test)
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1   # nordri repo root
+
+mode="${1:-test}"
+shell_files=(bootstrap.sh update-embedded-git.sh lib/*.sh tests/unit/*.sh tests/run.sh)
+
+syntax_check() {
+  local f rc=0
+  for f in "${shell_files[@]}"; do
+    if ! bash -n "$f"; then echo "  bash -n FAILED: $f" >&2; rc=1; fi
+  done
+  return $rc
+}
+
+case "$mode" in
+  lint)
+    if command -v shellcheck >/dev/null 2>&1; then
+      shellcheck "${shell_files[@]}"
+    else
+      echo "shellcheck not installed — falling back to 'bash -n' syntax lint."
+      syntax_check
+    fi
+    ;;
+  test)
+    echo "== syntax check =="
+    syntax_check || exit 1
+    echo "== unit tests =="
+    fails=0
+    for t in tests/unit/*.sh; do
+      echo "RUN $t"
+      bash "$t" || fails=$((fails + 1))
+    done
+    if [ "$fails" -ne 0 ]; then
+      echo "❌ $fails unit-test file(s) FAILED" >&2
+      exit 1
+    fi
+    echo "✅ nordri: syntax clean + all unit tests pass"
+    ;;
+  *)
+    echo "Usage: tests/run.sh [test|lint]" >&2
+    exit 2
+    ;;
+esac

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -7,6 +7,7 @@
 # Usage: tests/run.sh [test|lint]   (default: test)
 set -uo pipefail
 cd "$(dirname "$0")/.." || exit 1   # nordri repo root
+shopt -s nullglob   # an empty glob (e.g. lib/*.sh) drops out instead of passing the literal pattern
 
 mode="${1:-test}"
 shell_files=(bootstrap.sh update-embedded-git.sh lib/*.sh tests/unit/*.sh tests/run.sh)

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,6 +32,10 @@ case "$mode" in
   test)
     echo "== syntax check =="
     syntax_check || exit 1
+    if ! command -v jq >/dev/null 2>&1; then
+      echo "❌ jq is required to run the unit tests (lib/gitea.sh uses it). Install jq and re-run." >&2
+      exit 1
+    fi
     echo "== unit tests =="
     fails=0
     for t in tests/unit/*.sh; do

--- a/tests/unit/gitea-urls-test.sh
+++ b/tests/unit/gitea-urls-test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -uo pipefail
+. "$(cd "$(dirname "$0")" && pwd)/../../lib/gitea.sh"
+
+fails=0
+check() { if eval "$2"; then echo "ok - $1"; else echo "NOT OK - $1"; fails=$((fails+1)); fi; }
+
+GITEA_SCHEME=http; GITEA_HOST=localhost:3000; GITEA_USER='nordri-admin'; GITEA_PASS='p@ss:/w#rd'
+gitea_build_urls
+check "api url built" "[ \"\$GITEA_API_URL\" = 'http://localhost:3000' ]"
+check "probe url built" "[ \"\$GITEA_PROBE_URL\" = 'http://localhost:3000/api/v1/version' ]"
+check "git base percent-encodes creds" "printf '%s' \"\$GITEA_GIT_BASE\" | grep -q 'nordri-admin:p%40ss%3A%2Fw%23rd@localhost:3000'"
+
+echo "---"; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/tests/unit/hydrate-prepare-test.sh
+++ b/tests/unit/hydrate-prepare-test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -uo pipefail
+. "$(cd "$(dirname "$0")" && pwd)/../../lib/hydrate.sh"
+
+fails=0
+check() { if eval "$2"; then echo "ok - $1"; else echo "NOT OK - $1"; fails=$((fails+1)); fi; }
+
+src="$(mktemp -d)"; dst="$(mktemp -d)"; trap 'rm -rf "$src" "$dst"' EXIT
+mkdir -p "$src/.git" "$src/apps"
+echo x > "$src/apps/a.yaml"
+echo secret > "$src/.git/config"
+
+hydrate_prepare_tree "$src" "$dst"
+check "content copied" "[ -f '$dst/apps/a.yaml' ]"
+check ".git stripped" "[ ! -e '$dst/.git' ]"
+
+echo "---"; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/tests/unit/patch-nidavellir-test.sh
+++ b/tests/unit/patch-nidavellir-test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+. "$HERE/../../lib/patch-nidavellir.sh"
+
+fails=0
+check() { if eval "$2"; then echo "ok - $1"; else echo "NOT OK - $1"; fails=$((fails+1)); fi; }
+
+# Arrange: a fake hydrated tree carrying the placeholder strings.
+tree="$(mktemp -d)"; trap 'rm -rf "$tree"' EXIT
+mkdir -p "$tree/apps"
+printf 'path: vegvisir/manifests/overlays/homelab\n' > "$tree/apps/vegvisir-app.yaml"
+printf 'hostname: tailscale-operator-MACHINE\n'      > "$tree/apps/tailscale-operator-app.yaml"
+
+# Act + assert: homelab target rewrites overlay to homelab and stamps a host name.
+out="$(patch_nidavellir_tree "$tree" homelab)"; rc=$?
+check "homelab returns 0" "[ $rc -eq 0 ]"
+check "vegvisir overlay stays homelab" "grep -q 'overlays/homelab' '$tree/apps/vegvisir-app.yaml'"
+check "tailscale hostname stamped (not literal MACHINE)" "! grep -q 'tailscale-operator-MACHINE' '$tree/apps/tailscale-operator-app.yaml'"
+
+# gke target rewrites overlay to gke and uses the fixed gke hostname.
+printf 'path: vegvisir/manifests/overlays/homelab\n' > "$tree/apps/vegvisir-app.yaml"
+printf 'hostname: tailscale-operator-MACHINE\n'      > "$tree/apps/tailscale-operator-app.yaml"
+patch_nidavellir_tree "$tree" gke >/dev/null
+check "gke overlay rewritten" "grep -q 'overlays/gke' '$tree/apps/vegvisir-app.yaml'"
+check "gke hostname is tailscale-operator-gke" "grep -q 'tailscale-operator-gke' '$tree/apps/tailscale-operator-app.yaml'"
+
+# Renamed placeholder must fail loudly (verification catches a no-op sed).
+printf 'path: vegvisir/manifests/overlays/RENAMED\n' > "$tree/apps/vegvisir-app.yaml"
+printf 'hostname: tailscale-operator-MACHINE\n'      > "$tree/apps/tailscale-operator-app.yaml"
+patch_nidavellir_tree "$tree" homelab >/dev/null 2>&1; rc=$?
+check "renamed vegvisir placeholder returns non-zero" "[ $rc -ne 0 ]"
+
+# Missing file must fail loudly.
+rm -f "$tree/apps/vegvisir-app.yaml"
+patch_nidavellir_tree "$tree" homelab >/dev/null 2>&1; rc=$?
+check "missing manifest returns non-zero" "[ $rc -ne 0 ]"
+
+echo "---"; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/tests/unit/patch-nidavellir-test.sh
+++ b/tests/unit/patch-nidavellir-test.sh
@@ -36,4 +36,10 @@ rm -f "$tree/apps/vegvisir-app.yaml"
 patch_nidavellir_tree "$tree" homelab >/dev/null 2>&1; rc=$?
 check "missing manifest returns non-zero" "[ $rc -ne 0 ]"
 
+# Empty/unknown target must fail fast (not silently corrupt the overlay path).
+printf 'path: vegvisir/manifests/overlays/homelab\n' > "$tree/apps/vegvisir-app.yaml"
+printf 'hostname: tailscale-operator-MACHINE\n'      > "$tree/apps/tailscale-operator-app.yaml"
+patch_nidavellir_tree "$tree" "" >/dev/null 2>&1; rc=$?
+check "empty target returns non-zero" "[ $rc -ne 0 ]"
+
 echo "---"; [ "$fails" -eq 0 ] && echo "ALL PASS" || { echo "$fails FAILED"; exit 1; }

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -50,11 +50,25 @@ TARGET=$1
 # Validate args before anything that touches the cluster, so wrong inputs
 # fail with a usage message instead of an obscure k8s/credential error.
 if [[ -z "$TARGET" ]]; then
-    echo "Usage: ./update-embedded-git.sh [gke|homelab]"
+    echo "Usage: ./update-embedded-git.sh [gke|homelab] [realm]"
     exit 1
 fi
 if [[ "$TARGET" != "gke" && "$TARGET" != "homelab" ]]; then
     echo "Error: Target must be 'gke' or 'homelab'"
+    exit 1
+fi
+
+# Optional owning realm (arg 2): refresh its cluster/ subtree in the seed so
+# ArgoCD picks up realm-owned config changes. REALM_DIR overrides the default
+# <workspace>/realms/<realm> resolution. Omit for a demo-only stack.
+REALM="${2:-}"
+REALM_DIR="${REALM_DIR:-}"
+if [[ -n "$REALM" && -z "$REALM_DIR" ]]; then
+    REALM_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")/realms/$REALM"
+fi
+if [[ -n "$REALM" && ! -d "$REALM_DIR/cluster" ]]; then
+    echo "❌ Owning realm '$REALM' has no cluster/ config at: $REALM_DIR/cluster" >&2
+    echo "   Pass a realm whose repo carries cluster/, set REALM_DIR, or omit the arg for demo-only." >&2
     exit 1
 fi
 
@@ -250,6 +264,12 @@ hydrate_working_tree_repo "$HEIMDALL_DIR" "$HEIMDALL_GITEA_REPO" "Update for $TA
 # Vendor mirrors: push real history + tags so in-cluster apps can pin exact
 # upstream refs. See lib/hydrate.sh for the heads-vs-tags prune rationale.
 hydrate_vendor_mirrors "$VENDOR_MIRRORS"
+
+# Owning realm (optional): refresh its cluster/ subtree so ArgoCD re-syncs
+# realm-owned config. (The realm root-app itself is registered by bootstrap.sh.)
+if [[ -n "$REALM_DIR" ]]; then
+    hydrate_working_tree_repo "$REALM_DIR/cluster" "$REALM" "Realm config for $TARGET"
+fi
 
 echo "✅ Configuration Updated."
 echo "🔄 Triggering ArgoCD Sync (Root App)..."

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -62,6 +62,12 @@ fi
 # ArgoCD picks up realm-owned config changes. REALM_DIR overrides the default
 # <workspace>/realms/<realm> resolution. Omit for a demo-only stack.
 REALM="${2:-}"
+if [[ -n "$REALM" ]]; then
+    if [[ ! "$REALM" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]] || [[ ${#REALM} -gt 63 ]]; then
+        echo "❌ Realm '$REALM' must be a DNS-1123 label (lowercase alphanumeric and '-', max 63 chars) — it names a Gitea repo and a Kubernetes Application." >&2
+        exit 1
+    fi
+fi
 REALM_DIR="${REALM_DIR:-}"
 if [[ -n "$REALM" && -z "$REALM_DIR" ]]; then
     REALM_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")/realms/$REALM"
@@ -99,6 +105,10 @@ HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
 # Day-2 hydration commits are authored as "Nordri Update" (bootstrap uses the default).
 HYDRATE_COMMITTER="Nordri Update"
+# Recreate lost seed repos with auto_init so Gitea has a resolvable HEAD (ArgoCD
+# targetRevision: HEAD). No-op for existing repos (409) — it only matters on the
+# rotation-recovery path this script is explicitly resilient to.
+HYDRATE_AUTO_INIT=true
 
 # Resolve Gitea admin credentials.
 #
@@ -233,9 +243,9 @@ cp "$SCRIPT_DIR/platform/root-app.yaml" "$HYDRATE_DIR/"
 # runs without persistence; if the pod ever rotates and the repo got lost
 # (we hit exactly this earlier — postgres survived but blob storage
 # didn't), `git push` would fail with a misleading "remote rejected"
-# error. ensure_gitea_repo treats 201/409 as success and retries
-# transport errors.
-gitea_ensure_repo "$GITEA_REPO_NAME"
+# error. gitea_ensure_repo treats 201/409 as success and retries transport
+# errors; auto_init (HYDRATE_AUTO_INIT) gives a recreated repo a resolvable HEAD.
+gitea_ensure_repo "$GITEA_REPO_NAME" "$HYDRATE_AUTO_INIT"
 
 # Push to Gitea
 cd $HYDRATE_DIR

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -41,6 +41,8 @@ set -e
 #               to ../<name> relative to this script.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Shared hydration library (extracted from the duplicated inline blocks).
+. "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 
 # Validate args before anything that touches the cluster, so wrong inputs
@@ -294,51 +296,7 @@ if [[ -d "$NIDAVELLIR_DIR" ]]; then
     cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
     rm -rf "$NIDAVELLIR_HYDRATE/.git"
 
-    # Per-target patching of the hydrated nidavellir tree (mirrors the nordri
-    # app-of-apps overlay sed above). Two cluster-specific rewrites:
-    #   1. Point the vegvisir app at the env overlay so the LetsEncrypt issuers +
-    #      the *.cmdbee.org wildcard cert only land on GKE; homelab keeps the
-    #      self-signed Gateway cert so its websecure listener programs.
-    #   2. Stamp the tailscale operator hostname. GKE is a single shared cluster,
-    #      so it gets a stable `tailscale-operator-gke`; each homelab cluster is
-    #      per-machine (one cluster per Mac) so it gets `tailscale-operator-<machine>`
-    #      to avoid tailnet device-name collisions. The workstation name is a valid
-    #      identity only for homelab — deriving it on GKE would churn the device
-    #      name between hydrations run from different machines.
-    # Guard: these apps must exist in the hydrated tree; a missing path (e.g. a
-    # nidavellir apps/ rename) would otherwise abort with a bare `sed` error.
-    _nid_vegvisir_app="$NIDAVELLIR_HYDRATE/apps/vegvisir-app.yaml"
-    _nid_tailscale_app="$NIDAVELLIR_HYDRATE/apps/tailscale-operator-app.yaml"
-    for _nid_f in "$_nid_vegvisir_app" "$_nid_tailscale_app"; do
-        if [[ ! -f "$_nid_f" ]]; then
-            echo "❌ Expected nidavellir manifest missing: ${_nid_f#"$NIDAVELLIR_HYDRATE"/} — has apps/ been renamed? Cannot apply the per-target patch." >&2
-            exit 1
-        fi
-    done
-    if [[ "$TARGET" == "gke" ]]; then
-        TS_HOSTNAME="tailscale-operator-gke"
-    else
-        NID_MACHINE="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || hostname)"
-        NID_MACHINE="$(printf '%s' "$NID_MACHINE" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-' | sed 's/^-*//;s/-*$//')"
-        [[ -z "$NID_MACHINE" ]] && NID_MACHINE="local"
-        TS_HOSTNAME="tailscale-operator-$NID_MACHINE"
-    fi
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
-        sed -i '' "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
-    else
-        sed -i "s|path: vegvisir/manifests/overlays/homelab|path: vegvisir/manifests/overlays/$TARGET|g" "$_nid_vegvisir_app"
-        sed -i "s|tailscale-operator-MACHINE|$TS_HOSTNAME|g" "$_nid_tailscale_app"
-    fi
-    # Verify the substitutions took effect — sed exits 0 even when nothing
-    # matched, so a renamed placeholder upstream would silently push the wrong
-    # overlay path / an unstamped hostname (the exact failure modes this prevents).
-    if ! grep -q "path: vegvisir/manifests/overlays/$TARGET" "$_nid_vegvisir_app"; then
-        echo "❌ vegvisir overlay path not patched — the 'overlays/homelab' placeholder may have changed in nidavellir." >&2
-        exit 1
-    fi
-    if ! grep -q "$TS_HOSTNAME" "$_nid_tailscale_app"; then
-        echo "❌ tailscale operator hostname not stamped — the 'tailscale-operator-MACHINE' placeholder may have changed in nidavellir." >&2
+    if ! TS_HOSTNAME="$(patch_nidavellir_tree "$NIDAVELLIR_HYDRATE" "$TARGET")"; then
         exit 1
     fi
     echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -41,7 +41,8 @@ set -e
 #               to ../<name> relative to this script.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-# Shared hydration library (extracted from the duplicated inline blocks).
+# Shared hydration libraries (extracted from the duplicated inline blocks).
+. "$SCRIPT_DIR/lib/gitea.sh"
 . "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 
@@ -128,58 +129,9 @@ fi
 # Build URL bases. `git remote add` requires creds embedded in the URL,
 # so we percent-encode user/pass to handle special chars (@, :, /, #).
 # API calls go through curl -u with the credentials-less base URL.
-urlencode() { jq -rn --arg s "$1" '$s|@uri'; }
-GITEA_USER_ENC="$(urlencode "$GITEA_USER")"
-GITEA_PASS_ENC="$(urlencode "$GITEA_PASS")"
-GITEA_API_URL="${GITEA_SCHEME}://${GITEA_HOST}"
-GITEA_GIT_BASE="${GITEA_SCHEME}://${GITEA_USER_ENC}:${GITEA_PASS_ENC}@${GITEA_HOST}"
-GITEA_PROBE_URL="${GITEA_API_URL}/api/v1/version"
+gitea_build_urls
 
-# Probe the Gitea endpoint for the current $GITEA_HOST. Returns 0 if Gitea
-# answers /api/v1/version with HTTP 200, non-zero otherwise. Avoids
-# silently sending credentials to a wrong endpoint or an unready ingress.
-probe_gitea() {
-    curl -fsS --max-time 5 "$GITEA_PROBE_URL" >/dev/null 2>&1
-}
-
-# Create a Gitea repo if it doesn't already exist. Treats 201 (Created)
-# and 409 (already exists) as success; anything else (DNS failure, auth
-# rejection, 5xx) retries up to 5x with a short backoff (matches
-# bootstrap.sh's create_gitea_repo — Seed Gitea can intermittently fail
-# sequential creates due to an `initRepository` race), then prints the
-# response body and fails the script.
-ensure_gitea_repo() {
-    local repo_name=$1
-    local max_retries=5
-    local i status response_file
-    for i in $(seq 1 $max_retries); do
-        response_file=$(mktemp)
-        # `-u user:pass` keeps credentials out of the URL so special chars
-        # in $GITEA_PASS can't corrupt URL parsing.
-        status=$(curl -sS -o "$response_file" -w "%{http_code}" \
-            -u "$GITEA_USER:$GITEA_PASS" \
-            -X POST "$GITEA_API_URL/api/v1/user/repos" \
-            -H "Content-Type: application/json" \
-            -d "{\"name\": \"$repo_name\", \"private\": false}") || true
-        case "$status" in
-            201|409)
-                rm -f "$response_file"
-                return 0
-                ;;
-        esac
-        if [[ $i -lt $max_retries ]]; then
-            echo "   Repo creation attempt $i/$max_retries for '$repo_name' returned HTTP $status; retrying in 5s..." >&2
-            rm -f "$response_file"
-            sleep 5
-            continue
-        fi
-        echo "❌ Failed to create or confirm Gitea repo '$repo_name' after $max_retries attempts (HTTP $status):" >&2
-        cat "$response_file" >&2
-        echo >&2
-        rm -f "$response_file"
-        return 1
-    done
-}
+# gitea_ensure_repo (create-if-missing; auto_init for fresh repos) lives in lib/gitea.sh.
 
 echo "🚀 Updating Nordri Configuration for target: $TARGET"
 
@@ -266,7 +218,7 @@ cp "$SCRIPT_DIR/platform/root-app.yaml" "$HYDRATE_DIR/"
 # didn't), `git push` would fail with a misleading "remote rejected"
 # error. ensure_gitea_repo treats 201/409 as success and retries
 # transport errors.
-ensure_gitea_repo "$GITEA_REPO_NAME"
+gitea_ensure_repo "$GITEA_REPO_NAME"
 
 # Push to Gitea
 cd $HYDRATE_DIR
@@ -289,7 +241,7 @@ echo "✅ Nordri configuration updated."
 if [[ -d "$NIDAVELLIR_DIR" ]]; then
     echo "💧 Updating Nidavellir in Seed Gitea..."
 
-    ensure_gitea_repo "$NIDAVELLIR_GITEA_REPO"
+    gitea_ensure_repo "$NIDAVELLIR_GITEA_REPO"
 
     NIDAVELLIR_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$NIDAVELLIR_HYDRATE")
@@ -322,7 +274,7 @@ fi
 if [[ -d "$MIMIR_DIR" ]]; then
     echo "💧 Updating Mimir in Seed Gitea..."
 
-    ensure_gitea_repo "$MIMIR_GITEA_REPO"
+    gitea_ensure_repo "$MIMIR_GITEA_REPO"
 
     MIMIR_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$MIMIR_HYDRATE")
@@ -350,7 +302,7 @@ fi
 if [[ -d "$HEIMDALL_DIR" ]]; then
     echo "💧 Updating Heimdall in Seed Gitea..."
 
-    ensure_gitea_repo "$HEIMDALL_GITEA_REPO"
+    gitea_ensure_repo "$HEIMDALL_GITEA_REPO"
 
     HEIMDALL_HYDRATE=$(mktemp -d)
     TEMP_DIRS+=("$HEIMDALL_HYDRATE")
@@ -401,7 +353,7 @@ for VENDOR in $VENDOR_MIRRORS; do
     # FILE, which a directory test would wrongly reject as "not cloned".
     if git -C "$VENDOR_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
         echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
-        ensure_gitea_repo "$VENDOR"
+        gitea_ensure_repo "$VENDOR"
         # Resolve the source remote robustly. `ws clone` names the remote after
         # the org (not "origin"), so prefer the checked-out branch's tracking
         # remote; fall back to the sole remote; warn-and-skip rather than guess

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -267,7 +267,7 @@ hydrate_vendor_mirrors "$VENDOR_MIRRORS"
 
 # Owning realm (optional): refresh its cluster/ subtree so ArgoCD re-syncs
 # realm-owned config. (The realm root-app itself is registered by bootstrap.sh.)
-if [[ -n "$REALM_DIR" ]]; then
+if [[ -n "$REALM" ]]; then
     hydrate_working_tree_repo "$REALM_DIR/cluster" "$REALM" "Realm config for $TARGET"
 fi
 

--- a/update-embedded-git.sh
+++ b/update-embedded-git.sh
@@ -43,6 +43,7 @@ set -e
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Shared hydration libraries (extracted from the duplicated inline blocks).
 . "$SCRIPT_DIR/lib/gitea.sh"
+. "$SCRIPT_DIR/lib/hydrate.sh"
 . "$SCRIPT_DIR/lib/patch-nidavellir.sh"
 TARGET=$1
 
@@ -82,6 +83,8 @@ HEIMDALL_DIR="${HEIMDALL_DIR:-$(dirname "$SCRIPT_DIR")/heimdall}"
 # tags (e.g. keycloak-operator pins targetRevision "26.6.3"). Space-
 # separated list of component dir names under the workspace components/.
 VENDOR_MIRRORS="${VENDOR_MIRRORS:-keycloak-k8s-resources}"
+# Day-2 hydration commits are authored as "Nordri Update" (bootstrap uses the default).
+HYDRATE_COMMITTER="Nordri Update"
 
 # Resolve Gitea admin credentials.
 #
@@ -238,155 +241,15 @@ rm -rf $HYDRATE_DIR
 echo "✅ Nordri configuration updated."
 
 # Also push Nidavellir so ArgoCD picks up any changes there too.
-if [[ -d "$NIDAVELLIR_DIR" ]]; then
-    echo "💧 Updating Nidavellir in Seed Gitea..."
+hydrate_working_tree_repo "$NIDAVELLIR_DIR" "$NIDAVELLIR_GITEA_REPO" "Update for $TARGET" patch_nidavellir_tree
 
-    gitea_ensure_repo "$NIDAVELLIR_GITEA_REPO"
+hydrate_working_tree_repo "$MIMIR_DIR" "$MIMIR_GITEA_REPO" "Update for $TARGET"
 
-    NIDAVELLIR_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$NIDAVELLIR_HYDRATE")
-    cp -r "$NIDAVELLIR_DIR/." "$NIDAVELLIR_HYDRATE/"
-    rm -rf "$NIDAVELLIR_HYDRATE/.git"
+hydrate_working_tree_repo "$HEIMDALL_DIR" "$HEIMDALL_GITEA_REPO" "Update for $TARGET"
 
-    if ! TS_HOSTNAME="$(patch_nidavellir_tree "$NIDAVELLIR_HYDRATE" "$TARGET")"; then
-        exit 1
-    fi
-    echo "   Patched nidavellir for target '$TARGET' (tailscale hostname: $TS_HOSTNAME)."
-
-    cd "$NIDAVELLIR_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Update"
-    git checkout -b main
-    git add .
-    git commit -m "Update for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$NIDAVELLIR_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$NIDAVELLIR_HYDRATE"
-
-    echo "✅ Nidavellir updated."
-else
-    echo "⚠️  Nidavellir directory not found at: $NIDAVELLIR_DIR"
-    echo "   Set NIDAVELLIR_DIR env var or clone nidavellir as a sibling of this repo."
-fi
-
-if [[ -d "$MIMIR_DIR" ]]; then
-    echo "💧 Updating Mimir in Seed Gitea..."
-
-    gitea_ensure_repo "$MIMIR_GITEA_REPO"
-
-    MIMIR_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$MIMIR_HYDRATE")
-    cp -r "$MIMIR_DIR/." "$MIMIR_HYDRATE/"
-    rm -rf "$MIMIR_HYDRATE/.git"
-
-    cd "$MIMIR_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Update"
-    git checkout -b main
-    git add .
-    git commit -m "Update for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$MIMIR_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$MIMIR_HYDRATE"
-
-    echo "✅ Mimir updated."
-else
-    echo "⚠️  Mimir directory not found at: $MIMIR_DIR"
-    echo "   Set MIMIR_DIR env var or clone mimir as a sibling of this repo."
-fi
-
-if [[ -d "$HEIMDALL_DIR" ]]; then
-    echo "💧 Updating Heimdall in Seed Gitea..."
-
-    gitea_ensure_repo "$HEIMDALL_GITEA_REPO"
-
-    HEIMDALL_HYDRATE=$(mktemp -d)
-    TEMP_DIRS+=("$HEIMDALL_HYDRATE")
-    cp -r "$HEIMDALL_DIR/." "$HEIMDALL_HYDRATE/"
-    rm -rf "$HEIMDALL_HYDRATE/.git"
-
-    cd "$HEIMDALL_HYDRATE"
-    git init
-    git config user.email "bootstrap@nordri.local"
-    git config user.name "Nordri Update"
-    git checkout -b main
-    git add .
-    git commit -m "Update for $TARGET"
-    git remote add origin "$GITEA_GIT_BASE/$GITEA_USER/$HEIMDALL_GITEA_REPO.git"
-    git push -u origin main --force
-    cd -
-    rm -rf "$HEIMDALL_HYDRATE"
-
-    echo "✅ Heimdall updated."
-else
-    echo "⚠️  Heimdall directory not found at: $HEIMDALL_DIR"
-    echo "   Set HEIMDALL_DIR env var or clone heimdall as a sibling of this repo."
-fi
-
-# Vendor mirrors: mirror the local clone into the seed so an in-cluster app
-# can pin ANY upstream ref — a tag (as keycloak-operator does) OR a branch (a
-# future vendor might). A normal `ws clone` keeps only the default branch as a
-# local head (refs/heads/*) and the rest under refs/remotes/<remote>/*, so we
-# push both: the heads glob carries the default branch reliably, and a loop
-# adds every non-default upstream branch from the remote-tracking namespace
-# (skipping the HEAD symref so we never push a bogus refs/heads/HEAD).
-#
-# Heads are pushed WITHOUT --prune on purpose: pruning the heads namespace
-# would try to delete the seed's default branch whenever a branch name isn't
-# in the source set, which Gitea rejects ("default branch cannot be deleted")
-# and fails the whole hydration. Tags DO get --prune — they're the drift-prone
-# refs (a retracted tag should disappear) and tag pruning can't hit that trap.
-# A branch deleted upstream lingers in the ephemeral seed until the next clean
-# bootstrap; nothing pins a deleted branch, so that's acceptable.
-#
-# Reads as-fetched remote-tracking refs (no network at hydrate time) — refresh
-# a mirror with `ws pull <vendor>`. Not `git push --mirror`: from a non-bare
-# clone it pushes refs/remotes/* verbatim (littering the seed) and carries any
-# refs/pull/* an upstream mirror has.
-for VENDOR in $VENDOR_MIRRORS; do
-    VENDOR_DIR="$(dirname "$SCRIPT_DIR")/$VENDOR"
-    # Plumbing check, not `-d .git`: a worktree or submodule has `.git` as a
-    # FILE, which a directory test would wrongly reject as "not cloned".
-    if git -C "$VENDOR_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-        echo "💧 Updating vendor mirror '$VENDOR' in Seed Gitea..."
-        gitea_ensure_repo "$VENDOR"
-        # Resolve the source remote robustly. `ws clone` names the remote after
-        # the org (not "origin"), so prefer the checked-out branch's tracking
-        # remote; fall back to the sole remote; warn-and-skip rather than guess
-        # if neither is determinable (picking head -n1 of several could push
-        # from the wrong refs/remotes/* namespace and clobber seed refs).
-        VENDOR_BRANCH="$(git -C "$VENDOR_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
-        VENDOR_REMOTE=""
-        [[ -n "$VENDOR_BRANCH" ]] && VENDOR_REMOTE="$(git -C "$VENDOR_DIR" config "branch.$VENDOR_BRANCH.remote" 2>/dev/null || true)"
-        if [[ -z "$VENDOR_REMOTE" ]]; then
-            _vr_count="$(git -C "$VENDOR_DIR" remote | grep -c .)"
-            if [[ "$_vr_count" != "1" ]]; then
-                echo "⚠️  Vendor mirror '$VENDOR' has $_vr_count remotes and no tracked upstream — skipping (set a single remote or a tracking branch)." >&2
-                continue
-            fi
-            VENDOR_REMOTE="$(git -C "$VENDOR_DIR" remote)"
-        fi
-        VENDOR_SEED="$GITEA_GIT_BASE/$GITEA_USER/$VENDOR.git"
-        # Default branch (reliably a local head) + every non-default upstream
-        # branch (remote-tracking, minus the HEAD symref), each mapped to a seed head.
-        VENDOR_REFSPECS=("+refs/heads/*:refs/heads/*")
-        while IFS= read -r _vref; do
-            _vbranch="${_vref#refs/remotes/$VENDOR_REMOTE/}"
-            [[ "$_vbranch" == "HEAD" ]] && continue
-            VENDOR_REFSPECS+=("+$_vref:refs/heads/$_vbranch")
-        done < <(git -C "$VENDOR_DIR" for-each-ref --format='%(refname)' "refs/remotes/$VENDOR_REMOTE")
-        git -C "$VENDOR_DIR" push --force "$VENDOR_SEED" "${VENDOR_REFSPECS[@]}"
-        git -C "$VENDOR_DIR" push --force --prune "$VENDOR_SEED" 'refs/tags/*:refs/tags/*'
-        echo "✅ Vendor mirror '$VENDOR' updated."
-    else
-        echo "⚠️  Vendor mirror '$VENDOR' not cloned at: $VENDOR_DIR"
-        echo "   Run 'ws clone $VENDOR' if apps on this cluster pin it."
-    fi
-done
+# Vendor mirrors: push real history + tags so in-cluster apps can pin exact
+# upstream refs. See lib/hydrate.sh for the heads-vs-tags prune rationale.
+hydrate_vendor_mirrors "$VENDOR_MIRRORS"
 
 echo "✅ Configuration Updated."
 echo "🔄 Triggering ArgoCD Sync (Root App)..."


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

- **Deduplicate the hydration logic** (the CodeRabbit finding on #21) into a sourced `lib/`: `lib/gitea.sh` (unified `gitea_ensure_repo` with an `auto_init` param — preserves bootstrap's fresh-repo HEAD behavior *and* day-2's no-init behavior), `lib/patch-nidavellir.sh` (the per-target vegvisir/tailscale patch), `lib/hydrate.sh` (tree hydration + vendor-mirror loop). Both `bootstrap.sh` and `update-embedded-git.sh` now source these; the six copy-pasted component blocks collapse to one-line calls.
- **Close the vendor-mirror-in-bootstrap gap:** `bootstrap.sh` now runs `hydrate_vendor_mirrors` too (it previously lived only in `update-embedded-git.sh`), so a fresh bootstrap hydrates `keycloak-k8s-resources` + its tags and the `26.6.3` pin resolves in-cluster without the manual day-2 step.
- **Owning-realm arg:** `bootstrap.sh <target> [realm]` (and `update-embedded-git.sh`) hydrates the realm's `cluster/` subtree into a seed-Gitea repo named after the realm, and `bootstrap.sh` registers a generic, templated **realm root-app** pointing ArgoCD at it (nordri commits no realm-specific value). No realm arg → generic demo-only stack.
- **Portability fixes found while validating on Windows:** `.gitattributes` pins `*.sh` to LF (a CRLF checkout breaks `bash` sourcing the new libs); `tests/run.sh` replaces the absent-on-Windows `make test`/`make lint` (the realm adapter is repointed at it in the companion realm PR).

## Test plan

- [x] `ws test nordri` — syntax check + plain-bash unit tests for the extracted lib functions (patch, gitea URL encoding, hydrate prepare).
- [x] **Live bootstrap on Docker Desktop** validated the changed behavior end-to-end: all components hydrated, `patch_nidavellir_tree` stamped the machine hostname, the vendor mirror pushed 91 refs incl. `26.6.3`, and the realm `cluster/` hydrated to a `realm-siliconsaga` seed repo.
- [ ] Full ArgoCD injection e2e (realm root-app → realm-import lands) — deferred to a proven substrate (Rancher Desktop / homelab); Docker Desktop's kind containerd can't pull `xpkg.crossplane.io` (Crossplane), an unrelated substrate issue.

## Related

- Closes #21 (hydration-logic dedup).
- Part of the realm-owned-stack-config train for SiliconSaga/nidavellir#20 (coordinate with the realm + nidavellir PRs; land realm `cluster/` + this nordri wiring before the nidavellir removal so the config is never homeless).
