### PR TITLE
fix(argocd): exclude *.template.yaml from nordri-root app-of-apps sync

### DIFF
--- a/platform/root-app.yaml
+++ b/platform/root-app.yaml
@@ -11,6 +11,12 @@ spec:
     repoURL: 'http://gitea-http.gitea.svc.cluster.local:3000/nordri-admin/nordri.git'
     targetRevision: HEAD
     path: platform/argocd # The App-of-Apps
+    directory:
+      # realm-root-app.template.yaml carries a __REALM_REPO__ placeholder and is
+      # rendered + applied directly by bootstrap.sh — it must never sync raw. An
+      # unrendered Application name fails RFC-1123 validation and breaks the
+      # whole app-of-apps sync (and everything downstream of it).
+      exclude: '*.template.yaml'
   destination:
     server: https://kubernetes.default.svc
     namespace: argo


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

`nordri-root`'s app-of-apps syncs `path: platform/argocd` wholesale, and that directory contains `realm-root-app.template.yaml` — a template with a raw `__REALM_REPO__` placeholder that `bootstrap.sh` renders (`sed` → `$REALM`) and applies directly. Synced raw by ArgoCD, it becomes an Application literally named `__REALM_REPO__`, which fails RFC-1123 name validation — so every `nordri-root` sync fails and the entire app-of-apps is blocked (the nidavellir platform apps never sync, the Keycloak-operator + ESO CRDs never appear, and realm injection can't apply).

**Fix:** `spec.source.directory.exclude: '*.template.yaml'` on `nordri-root`, so the bootstrap-rendered template is never synced raw.

## Test plan

- [x] Reproduced on a fresh Docker Desktop bootstrap: `nordri-root` stuck failing on the invalid `__REALM_REPO__` Application; the nidavellir platform + realm injection blocked behind it.
- [x] After the fix (re-applied `nordri-root` live): went Synced; the full nidavellir platform came up (cert-manager, ESO, keycloak-operator, keycloak, vegvisir, mimir, …); the realm's `siliconsaga-realm` KeycloakRealmImport + `leidangr-oidc-realm-secrets` ExternalSecret were injected (resting on the unseeded OpenBao path, as designed).

## Related

Latent since the realm-owned-config work merged — the earlier Docker Desktop validation died at the Crossplane provider layer (before ArgoCD synced the app-of-apps), so this path was never exercised until a Harbor pull-through mirror let the bootstrap complete.
