### PR TITLE
feat(cluster-identity): add harborRole/harborCentral for the Harbor composition

### DIFF
--- a/platform/fundamentals/manifests/cluster-identity-gke.yaml
+++ b/platform/fundamentals/manifests/cluster-identity-gke.yaml
@@ -12,3 +12,4 @@ data:
   environment: gke
   storageClass: standard-rwo
   domain: cmdbee.org
+  harborRole: central

--- a/platform/fundamentals/manifests/cluster-identity-homelab.yaml
+++ b/platform/fundamentals/manifests/cluster-identity-homelab.yaml
@@ -12,3 +12,5 @@ data:
   environment: homelab
   storageClass: local-path
   domain: homelab.local
+  harborRole: local
+  harborCentral: harbor.cmdbee.org


### PR DESCRIPTION
> **AI-assisted change proposal.** Filed by agent driven by @Cervator via [GDD](https://siliconsaga.github.io/yggdrasil/gdd/).

## Summary

Adds two keys to the `cluster-identity` `EnvironmentConfig` so the Harbor Crossplane composition can read its role from cluster-identity the same way it already reads `storageClass`/`domain` — no per-cluster claim divergence:

- **gke:** `harborRole: central`
- **homelab:** `harborRole: local` + `harborCentral: harbor.cmdbee.org`

`central` proxy-caches the origin registries and is the always-on public hub; `local` clusters run a cache that chains to `harborCentral`.

## Depends on / companion
- **SiliconSaga/nidavellir#24** — the Harbor stack-member composition that consumes these keys. This small prerequisite should land so that composition resolves its role live.

## Test plan
- [x] `kubectl apply --dry-run=client` on both `cluster-identity-{gke,homelab}.yaml` — valid.
- [x] Verified live via `crossplane render` in the nidavellir PR: the composition reads `harborRole`/`harborCentral` from these fixtures and renders the correct role (central → origins, local → central) per environment.
